### PR TITLE
Refactor dual camera app into modular components

### DIFF
--- a/camera_capture.py
+++ b/camera_capture.py
@@ -86,3 +86,36 @@ class MultiCameraCapture:
         """Yield the configured camera indices in the initial order."""
 
         return iter(self._indices)
+
+    def refresh_autofocus(self) -> bool:
+        """Attempt to retrigger auto focus on all opened cameras.
+
+        Returns
+        -------
+        bool
+            ``True`` if at least one capture acknowledged the autofocus
+            command, otherwise ``False``.
+        """
+
+        if not self.is_running():
+            return False
+
+        autofocus_prop = getattr(cv2, "CAP_PROP_AUTOFOCUS", None)
+        if autofocus_prop is None:
+            return False
+
+        refreshed = False
+        for capture in self._captures.values():
+            if capture is None or not capture.isOpened():
+                continue
+
+            # Toggle the autofocus flag to encourage the camera to refocus.
+            if capture.set(autofocus_prop, 0) and capture.set(autofocus_prop, 1):
+                refreshed = True
+                continue
+
+            # Some devices only allow enabling autofocus without toggling.
+            if capture.set(autofocus_prop, 1):
+                refreshed = True
+
+        return refreshed

--- a/camera_capture.py
+++ b/camera_capture.py
@@ -1,0 +1,88 @@
+"""Camera capture management for multi-camera setups."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional, Tuple
+
+import cv2
+
+
+class MultiCameraCapture:
+    """Utility class to manage multiple OpenCV camera capture devices.
+
+    Parameters
+    ----------
+    camera_indices:
+        Iterable of integer indices representing the cameras to open.
+    frame_size:
+        Optional ``(width, height)`` tuple. When provided, captured frames
+        are resized to this resolution before being returned.
+    backend:
+        Optional OpenCV backend identifier passed to ``cv2.VideoCapture``.
+    """
+
+    def __init__(
+        self,
+        camera_indices: Iterable[int],
+        frame_size: Optional[Tuple[int, int]] = (640, 360),
+        backend: int = cv2.CAP_ANY,
+    ) -> None:
+        self._indices = list(camera_indices)
+        self._frame_size = frame_size
+        self._backend = backend
+        self._captures: Dict[int, cv2.VideoCapture] = {}
+
+    def start(self) -> bool:
+        """Open all configured camera indices."""
+
+        if self.is_running():
+            return True
+
+        opened: Dict[int, cv2.VideoCapture] = {}
+        success = True
+        for index in self._indices:
+            capture = cv2.VideoCapture(index, self._backend)
+            if not capture.isOpened():
+                capture.release()
+                success = False
+                break
+            opened[index] = capture
+
+        if not success:
+            for capture in opened.values():
+                capture.release()
+            return False
+
+        self._captures = opened
+        return True
+
+    def stop(self) -> None:
+        """Release all opened camera handles."""
+
+        for capture in self._captures.values():
+            capture.release()
+        self._captures.clear()
+
+    def is_running(self) -> bool:
+        """Return ``True`` when at least one camera is opened."""
+
+        return bool(self._captures)
+
+    def read(self, index: int):
+        """Read a frame from the camera identified by ``index``."""
+
+        capture = self._captures.get(index)
+        if capture is None or not capture.isOpened():
+            return None
+
+        success, frame = capture.read()
+        if not success or frame is None:
+            return None
+
+        if self._frame_size is not None:
+            frame = cv2.resize(frame, self._frame_size)
+        return frame
+
+    def iter_indices(self) -> Iterable[int]:
+        """Yield the configured camera indices in the initial order."""
+
+        return iter(self._indices)

--- a/dual_invert_app.py
+++ b/dual_invert_app.py
@@ -1,0 +1,15 @@
+"""Entry point for the dual invert camera application."""
+
+import tkinter as tk
+
+from gui import DualInvertApp
+
+
+def main() -> None:
+    root = tk.Tk()
+    DualInvertApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/filters.py
+++ b/filters.py
@@ -1,10 +1,29 @@
 """Image processing filters for camera frames."""
+from __future__ import annotations
 
 import cv2
 import numpy as np
 
 
 def invert(frame: np.ndarray) -> np.ndarray:
-    """Return the color-inverted version of ``frame``."""
+    """Return a grayscale-inverted frame with red contours highlighting edges.
 
-    return cv2.bitwise_not(frame)
+    The input frame is converted to grayscale, inverted, and then converted
+    back to a 3-channel image so it can be rendered alongside color frames in
+    the GUI. Canny edge detection is used to extract the dominant geometry and
+    the detected contours are traced with a red outline for better visibility.
+    """
+    # Convert to grayscale to ensure the inversion only affects luminance.
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+    # Invert the grayscale image and convert it back to BGR for display.
+    inverted_gray = cv2.bitwise_not(gray)
+    inverted_bgr = cv2.cvtColor(inverted_gray, cv2.COLOR_GRAY2BGR)
+
+    # Detect edges and outline their contours in red to highlight geometry.
+    edges = cv2.Canny(gray, 100, 200)
+    contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if contours:
+        cv2.drawContours(inverted_bgr, contours, -1, (0, 0, 255), 1)
+
+    return inverted_bgr

--- a/filters.py
+++ b/filters.py
@@ -1,0 +1,10 @@
+"""Image processing filters for camera frames."""
+
+import cv2
+import numpy as np
+
+
+def invert(frame: np.ndarray) -> np.ndarray:
+    """Return the color-inverted version of ``frame``."""
+
+    return cv2.bitwise_not(frame)

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,137 @@
+"""Tkinter GUI for displaying multiple camera feeds and filters."""
+from __future__ import annotations
+
+import base64
+from typing import Dict, Iterable, List, Tuple
+
+import cv2
+import tkinter as tk
+from tkinter import ttk
+
+from camera_capture import MultiCameraCapture
+from filters import invert
+
+
+class DualInvertApp:
+    """GUI application showing original and inverted views for cameras."""
+
+    def __init__(
+        self,
+        root: tk.Tk,
+        camera_indices: Iterable[int] = (0, 1),
+    ) -> None:
+        self.root = root
+        self.root.title("Dual Kamera Ansicht mit Invertierung")
+
+        self._camera_indices: List[int] = list(camera_indices)
+        self._capture = MultiCameraCapture(self._camera_indices)
+        self._photo_images: Dict[Tuple[int, str], tk.PhotoImage] = {}
+
+        self.status_var = tk.StringVar(value="Inaktiv. Bitte 'Start' drücken.")
+
+        self._build_layout()
+        self.root.protocol("WM_DELETE_WINDOW", self.on_close)
+        self._update_loop()
+
+    def _build_layout(self) -> None:
+        main_frame = ttk.Frame(self.root, padding=10)
+        main_frame.pack(fill=tk.BOTH, expand=True)
+
+        control_frame = ttk.LabelFrame(main_frame, text="Steuerung", padding=10)
+        control_frame.pack(side=tk.LEFT, fill=tk.Y)
+
+        start_button = ttk.Button(control_frame, text="Start", command=self.start_cameras)
+        start_button.pack(fill=tk.X, pady=(0, 5))
+
+        stop_button = ttk.Button(control_frame, text="Stop", command=self.stop_cameras)
+        stop_button.pack(fill=tk.X)
+
+        status_label = ttk.Label(control_frame, textvariable=self.status_var, wraplength=140)
+        status_label.pack(fill=tk.X, pady=(15, 0))
+
+        video_frame = ttk.Frame(main_frame, padding=10)
+        video_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        self._labels: Dict[int, Dict[str, ttk.Label]] = {}
+
+        for row, index in enumerate(self._camera_indices):
+            self._labels[index] = {
+                "original": self._create_image_panel(
+                    video_frame, f"Kamera {row + 1} - Original", row, 0
+                ),
+                "inverted": self._create_image_panel(
+                    video_frame, f"Kamera {row + 1} - Invertiert", row, 1
+                ),
+            }
+
+        for row in range(len(self._camera_indices)):
+            video_frame.grid_rowconfigure(row, weight=1)
+        for column in range(2):
+            video_frame.grid_columnconfigure(column, weight=1)
+
+    def _create_image_panel(
+        self,
+        parent: ttk.Frame,
+        title: str,
+        row: int,
+        column: int,
+    ) -> ttk.Label:
+        panel = ttk.Frame(parent)
+        panel.grid(row=row, column=column, padx=5, pady=5, sticky="nsew")
+
+        label_title = ttk.Label(panel, text=title, anchor="center")
+        label_title.pack(fill=tk.X)
+
+        image_label = ttk.Label(panel, text="Kein Signal", anchor="center")
+        image_label.pack(fill=tk.BOTH, expand=True)
+
+        return image_label
+
+    def start_cameras(self) -> None:
+        if self._capture.is_running():
+            return
+
+        if not self._capture.start():
+            self.status_var.set("Fehler beim Öffnen der Kameras.")
+            self._capture.stop()
+            return
+
+        self.status_var.set("Live-Ansicht aktiv.")
+
+    def stop_cameras(self) -> None:
+        self._capture.stop()
+        self.status_var.set("Aufnahme gestoppt.")
+
+    def on_close(self) -> None:
+        self.stop_cameras()
+        self.root.destroy()
+
+    def _update_loop(self) -> None:
+        if self._capture.is_running():
+            for index in self._camera_indices:
+                frame = self._capture.read(index)
+                if frame is not None:
+                    self._update_image(self._labels[index]["original"], frame, (index, "original"))
+                    inverted = invert(frame)
+                    self._update_image(self._labels[index]["inverted"], inverted, (index, "inverted"))
+                else:
+                    self._clear_image(self._labels[index]["original"], (index, "original"))
+                    self._clear_image(self._labels[index]["inverted"], (index, "inverted"))
+
+        self.root.after(33, self._update_loop)
+
+    def _update_image(self, label: ttk.Label, frame, key: Tuple[int, str]) -> None:
+        rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        success, encoded_image = cv2.imencode(".png", rgb_frame)
+        if not success:
+            return
+
+        b64_data = base64.b64encode(encoded_image).decode("ascii")
+        photo = tk.PhotoImage(data=b64_data)
+
+        label.configure(image=photo, text="")
+        self._photo_images[key] = photo
+
+    def _clear_image(self, label: ttk.Label, key: Tuple[int, str]) -> None:
+        label.configure(image="", text="Kein Signal")
+        self._photo_images.pop(key, None)

--- a/gui.py
+++ b/gui.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 import base64
+from datetime import datetime
+from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
 
 import cv2
+import numpy as np
 import tkinter as tk
 from tkinter import ttk
 
@@ -26,6 +29,7 @@ class DualInvertApp:
         self._camera_indices: List[int] = list(camera_indices)
         self._capture = MultiCameraCapture(self._camera_indices)
         self._photo_images: Dict[Tuple[int, str], tk.PhotoImage] = {}
+        self._last_frames: Dict[int, Dict[str, np.ndarray]] = {}
 
         self.status_var = tk.StringVar(value="Inaktiv. Bitte 'Start' drücken.")
 
@@ -45,6 +49,21 @@ class DualInvertApp:
 
         stop_button = ttk.Button(control_frame, text="Stop", command=self.stop_cameras)
         stop_button.pack(fill=tk.X)
+
+        save_button = ttk.Button(
+            control_frame, text="Speichern", command=self.save_frames
+        )
+        save_button.pack(fill=tk.X, pady=(5, 0))
+
+        autofocus_button = ttk.Button(
+            control_frame,
+            text="Refresh Auto Fokus",
+            command=self.refresh_autofocus,
+        )
+        autofocus_button.pack(fill=tk.X, pady=(5, 0))
+
+        quit_button = ttk.Button(control_frame, text="Beenden", command=self.on_close)
+        quit_button.pack(fill=tk.X, pady=(5, 0))
 
         status_label = ttk.Label(control_frame, textvariable=self.status_var, wraplength=140)
         status_label.pack(fill=tk.X, pady=(15, 0))
@@ -106,17 +125,67 @@ class DualInvertApp:
         self.stop_cameras()
         self.root.destroy()
 
+    def refresh_autofocus(self) -> None:
+        if not self._capture.is_running():
+            self.status_var.set("Autofokus nur bei aktiver Aufnahme möglich.")
+            return
+
+        if self._capture.refresh_autofocus():
+            self.status_var.set("Autofokus wurde neu kalibriert.")
+        else:
+            self.status_var.set("Autofokus wird von den Kameras nicht unterstützt.")
+
+    def save_frames(self) -> None:
+        if not self._last_frames:
+            self.status_var.set("Keine Bilder zum Speichern verfügbar.")
+            return
+
+        output_dir = Path("captures")
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        saved = 0
+        for index, views in self._last_frames.items():
+            for view_name, image in views.items():
+                if image is None:
+                    continue
+                filename = output_dir / f"kamera{index}_{view_name}_{timestamp}.png"
+                if cv2.imwrite(str(filename), image):
+                    saved += 1
+
+        if saved:
+            self.status_var.set(
+                f"{saved} Bilder gespeichert im Ordner '{output_dir}'."
+            )
+        else:
+            self.status_var.set("Speichern fehlgeschlagen.")
+
     def _update_loop(self) -> None:
         if self._capture.is_running():
             for index in self._camera_indices:
                 frame = self._capture.read(index)
                 if frame is not None:
-                    self._update_image(self._labels[index]["original"], frame, (index, "original"))
+                    original_frame = frame.copy()
                     inverted = invert(frame)
-                    self._update_image(self._labels[index]["inverted"], inverted, (index, "inverted"))
+
+                    self._last_frames.setdefault(index, {})
+                    self._last_frames[index]["original"] = original_frame
+                    self._last_frames[index]["inverted"] = inverted.copy()
+
+                    self._update_image(
+                        self._labels[index]["original"],
+                        original_frame,
+                        (index, "original"),
+                    )
+                    self._update_image(
+                        self._labels[index]["inverted"],
+                        inverted,
+                        (index, "inverted"),
+                    )
                 else:
                     self._clear_image(self._labels[index]["original"], (index, "original"))
                     self._clear_image(self._labels[index]["inverted"], (index, "inverted"))
+                    self._last_frames.pop(index, None)
 
         self.root.after(33, self._update_loop)
 
@@ -135,3 +204,8 @@ class DualInvertApp:
     def _clear_image(self, label: ttk.Label, key: Tuple[int, str]) -> None:
         label.configure(image="", text="Kein Signal")
         self._photo_images.pop(key, None)
+        index, view_name = key
+        if index in self._last_frames:
+            self._last_frames[index].pop(view_name, None)
+            if not self._last_frames[index]:
+                self._last_frames.pop(index)


### PR DESCRIPTION
## Summary
- add a Tkinter-based application that displays both camera feeds alongside inverted versions in a single frame via a dedicated GUI module
- embed Start/Stop controls on the left and show live status updates using refactored capture management
- extract the OpenCV capture workflow and invert filter into separate modules with an entry script wrapper

## Testing
- python -m compileall camera_capture.py filters.py gui.py dual_invert_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cab8fd846c8326ae1266bc7cc9665a