### PR TITLE
Add circle detection filter for camera 0 and display in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Camera Capture
+
+Dieses Projekt stellt eine kleine Tk-Anwendung bereit, die zwei Kameras gleichzeitig
+anzeigt, invertierte Graustufen berechnet, Canny-Kanten hervorhebt und – sofern eine
+Stereo-Kalibrierung vorliegt – eine 3D-Tiefenansicht erzeugt.
+
+## Stereo-Kalibrierung durchführen
+
+1. **Schachbrett aufnehmen**  
+   Nimm pro Kamera mehrere synchronisierte Bilder des 6×6-Kalibrierfeldes auf.
+   Die Bilder beider Kameras müssen jeweils dieselbe Auflösung besitzen.
+
+2. **Kalibrierung berechnen**  
+   Verwende das Modul `stereo_reconstruction.py`, um aus den Bildpaaren die
+   Intrinsik und Extrinsik der Kameras zu bestimmen:
+
+   ```python
+   from pathlib import Path
+
+   import cv2
+   import stereo_reconstruction as sr
+
+   # Beispiel: Bilder aus einem Ordner laden
+   pairs = []
+   for i in range(1, 21):
+       left = cv2.imread(f"calib/left_{i:02d}.png")
+       right = cv2.imread(f"calib/right_{i:02d}.png")
+       if left is None or right is None:
+           continue
+       pairs.append((left, right))
+
+   calibration = sr.compute_stereo_calibration(pairs, pattern_size=(6, 6), square_size=1.0)
+   sr.save_calibration(Path("stereo_calibration.json"), calibration)
+   ```
+
+   Das Script erkennt automatisch gültige Schachbrettpaare, optimiert die Ecke
+   subpixelgenau und speichert alle Parameter samt Reprojektionsfehler.
+
+3. **Datei ablegen**  
+   Lege die erzeugte `stereo_calibration.json` im Projektstammverzeichnis ab.
+   Die GUI lädt die Datei beim Start und zeigt in der ersten Kamerazeile ein
+   zusätzliches Panel **„3D Ansicht“** an. Fehlt die Kalibrierung, bleibt das
+   Panel mit einem Hinweis deaktiviert.
+
+## Live-Bedienung
+
+* **Start / Stop** – Öffnet bzw. schließt die konfigurierten Kameras.
+* **Speichern** – Schreibt alle zuletzt angezeigten Ansichten in den Ordner
+  `captures/`.
+* **Refresh Auto Fokus** – Versucht, den Autofokus der Kameras neu zu triggern.
+* **Beenden** – Schließt die Anwendung.
+
+Das Originalbild wird mit ca. 30 FPS aktualisiert. Die Canny-Kanten sowie die
+Stereo-Rekonstruktion laufen aus Performance-Gründen auf ~6–7 FPS.

--- a/calibrate_stereo.py
+++ b/calibrate_stereo.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import cv2
+import stereo_reconstruction as sr  # dein Modul
+
+pairs_dir = Path("data/stereo_pairs")
+left_prefix = "kamera0_"
+right_prefix = "kamera1_"
+extensions = {".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff"}
+
+lefts = sorted([p for p in pairs_dir.iterdir() if p.suffix.lower() in extensions and p.name.startswith(left_prefix)])
+rights = sorted([p for p in pairs_dir.iterdir() if p.suffix.lower() in extensions and p.name.startswith(right_prefix)])
+
+if len(lefts) != len(rights) or len(lefts) == 0:
+    raise RuntimeError(f"Anzahl linke ({len(lefts)}) vs. rechte ({len(rights)}) Bilder passt nicht oder ist 0.")
+
+def index_of(name: str, prefix: str) -> str:
+    core = name[len(prefix):]
+    return core.split(".")[0]
+
+left_map = {index_of(p.name, left_prefix): p for p in lefts}
+right_map = {index_of(p.name, right_prefix): p for p in rights}
+common_keys = sorted(set(left_map.keys()) & set(right_map.keys()))
+if not common_keys:
+    raise RuntimeError("Keine passenden Index-Paare gefunden (Namensschema prüfen).")
+
+pairs_imgs = []
+for k in common_keys:
+    Lp = left_map[k]
+    Rp = right_map[k]
+
+    # 1) Farbig einlesen (empfohlen, weil _find_corners BGR->Gray macht)
+    imgL = cv2.imread(str(Lp), cv2.IMREAD_COLOR)
+    imgR = cv2.imread(str(Rp), cv2.IMREAD_COLOR)
+
+    # Falls aus irgendeinem Grund doch 1-Kanal reinkommt: robust nach BGR konvertieren
+    if imgL is None or imgR is None:
+        raise RuntimeError(f"Konnte Bilder nicht lesen: {Lp} / {Rp}")
+    if len(imgL.shape) == 2:
+        imgL = cv2.cvtColor(imgL, cv2.COLOR_GRAY2BGR)
+    if len(imgR.shape) == 2:
+        imgR = cv2.cvtColor(imgR, cv2.COLOR_GRAY2BGR)
+
+    if imgL.shape[:2] != imgR.shape[:2]:
+        raise RuntimeError(f"Auflösungen ungleich bei Paar {k}: {imgL.shape} vs {imgR.shape}")
+
+    pairs_imgs.append((imgL, imgR))
+
+print(f"Gefundene, geprüfte Paare: {len(pairs_imgs)}")
+
+# Optional: Falls dein sr.compute_stereo_calibration ein pattern_size braucht:
+# calibration = sr.compute_stereo_calibration(pairs_imgs, pattern_size=(9,6))
+calibration = sr.compute_stereo_calibration(pairs_imgs)
+
+out_file = Path("stereo_calibration.json")
+sr.save_calibration(out_file, calibration)
+print(f"Kalibrierungsdatei geschrieben: {out_file.resolve()}")

--- a/camera_capture.py
+++ b/camera_capture.py
@@ -23,7 +23,7 @@ class MultiCameraCapture:
     def __init__(
         self,
         camera_indices: Iterable[int],
-        frame_size: Optional[Tuple[int, int]] = (640, 360),
+        frame_size: Optional[Tuple[int, int]] = (640, 480),
         backend: int = cv2.CAP_ANY,
     ) -> None:
         self._indices = list(camera_indices)

--- a/camera_capture.py
+++ b/camera_capture.py
@@ -46,8 +46,10 @@ class MultiCameraCapture:
                 success = False
                 break
 
-            # Limit the capture rate to 10 frames per second when supported.
-            capture.set(cv2.CAP_PROP_FPS, 10)
+            # Drive the live preview at roughly 30 frames per second when
+            # supported by the connected cameras. If the device ignores this
+            # request OpenCV simply retains its default capture rate.
+            capture.set(cv2.CAP_PROP_FPS, 30)
             opened[index] = capture
 
         if not success:

--- a/camera_capture.py
+++ b/camera_capture.py
@@ -45,6 +45,9 @@ class MultiCameraCapture:
                 capture.release()
                 success = False
                 break
+
+            # Limit the capture rate to 10 frames per second when supported.
+            capture.set(cv2.CAP_PROP_FPS, 10)
             opened[index] = capture
 
         if not success:

--- a/filters.py
+++ b/filters.py
@@ -27,3 +27,123 @@ def invert(frame: np.ndarray) -> np.ndarray:
         cv2.drawContours(inverted_bgr, contours, -1, (0, 0, 255), 1)
 
     return inverted_bgr
+
+
+def detect_small_circles(frame: np.ndarray) -> np.ndarray:
+    """Detect and visualize circular features with normalized radii.
+
+    The filter highlights the largest circles in the scene and analyses the
+    remaining detections for groups of similarly sized circles. When at least
+    three circles with comparable radii are found, their mean radius is used to
+    render all non-maximal circles with a consistent size. The intention is to
+    stabilise the visualisation of the small circular holes in the workpiece
+    despite noisy detections.
+    """
+
+    if frame is None or frame.ndim != 3:
+        return frame
+
+    output = frame.copy()
+
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    blurred = cv2.GaussianBlur(gray, (9, 9), 2.0)
+
+    circles = cv2.HoughCircles(
+        blurred,
+        cv2.HOUGH_GRADIENT,
+        dp=1.2,
+        minDist=20,
+        param1=120,
+        param2=35,
+        minRadius=5,
+        maxRadius=0,
+    )
+
+    if circles is None or not len(circles):
+        return output
+
+    circles = np.round(circles[0]).astype(int)
+    circle_list = [(int(x), int(y), int(r)) for x, y, r in circles]
+    circle_list.sort(key=lambda c: c[2], reverse=True)
+
+    largest_radius = circle_list[0][2]
+    large_threshold = max(5, int(largest_radius * 0.8))
+    large_circles = [c for c in circle_list if c[2] >= large_threshold]
+    large_circle_set = {tuple(c) for c in large_circles}
+
+    groups = []
+    for circle in circle_list:
+        if tuple(circle) in large_circle_set:
+            continue
+        radius = circle[2]
+        placed = False
+        for group in groups:
+            tolerance = max(2.0, 0.08 * group["mean_radius"])
+            if abs(group["mean_radius"] - radius) <= tolerance:
+                group["members"].append(circle)
+                group["mean_radius"] = float(
+                    np.mean([member[2] for member in group["members"]])
+                )
+                placed = True
+                break
+        if not placed:
+            groups.append({"mean_radius": float(radius), "members": [circle]})
+
+    repeated_group = None
+    for group in groups:
+        if len(group["members"]) < 3:
+            continue
+        if repeated_group is None:
+            repeated_group = group
+            continue
+        if len(group["members"]) > len(repeated_group["members"]):
+            repeated_group = group
+            continue
+        if (
+            len(group["members"]) == len(repeated_group["members"])
+            and group["mean_radius"] < repeated_group["mean_radius"]
+        ):
+            repeated_group = group
+
+    normalised_radius = None
+    if repeated_group is not None:
+        normalised_radius = int(round(repeated_group["mean_radius"]))
+
+    small_candidates = [
+        circle for circle in circle_list if tuple(circle) not in large_circle_set
+    ]
+
+    for x, y, radius in large_circles:
+        cv2.circle(output, (x, y), radius, (255, 0, 0), 2)
+        cv2.circle(output, (x, y), 2, (255, 0, 0), 3)
+
+    if normalised_radius is not None:
+        for x, y, _ in small_candidates:
+            cv2.circle(output, (x, y), normalised_radius, (0, 255, 0), 2)
+            cv2.circle(output, (x, y), 2, (0, 255, 0), 3)
+        cv2.putText(
+            output,
+            f"Mittelradius: {normalised_radius}px",
+            (10, 30),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.7,
+            (0, 255, 0),
+            2,
+            cv2.LINE_AA,
+        )
+    else:
+        for x, y, radius in small_candidates:
+            cv2.circle(output, (x, y), radius, (0, 255, 255), 1)
+            cv2.circle(output, (x, y), 2, (0, 255, 255), 3)
+        cv2.putText(
+            output,
+            "Nicht genug gleich große Kreise gefunden",
+            (10, 30),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            (0, 0, 255),
+            1,
+            cv2.LINE_AA,
+        )
+
+    return output

--- a/filters.py
+++ b/filters.py
@@ -1,4 +1,4 @@
-"""Image processing filters for camera frames."""
+"""Grayscale inversion and Canny edge filters for camera frames."""
 from __future__ import annotations
 
 from typing import Tuple
@@ -7,53 +7,31 @@ import cv2
 import numpy as np
 
 
-def invert(frame: np.ndarray) -> np.ndarray:
-    """Return a grayscale-inverted frame with edge highlights.
-
-    The input frame is converted to grayscale, inverted and converted back to
-    BGR so it can be rendered alongside the colour streams in the GUI. Canny
-    edges are detected on the original luminance channel and drawn in red to
-    improve the visibility of structural features.
-    """
+def invert_grayscale(frame: np.ndarray) -> np.ndarray:
+    """Convert *frame* to grayscale, invert it, and return a 3-channel image."""
 
     if frame is None or frame.ndim != 3:
         return frame
 
     gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-    inverted_gray = cv2.bitwise_not(gray)
-    inverted_bgr = cv2.cvtColor(inverted_gray, cv2.COLOR_GRAY2BGR)
-
-    edges = cv2.Canny(gray, 100, 200)
-    contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-    if contours:
-        cv2.drawContours(inverted_bgr, contours, -1, (0, 0, 255), 1)
-
-    return inverted_bgr
+    inverted = cv2.bitwise_not(gray)
+    return cv2.cvtColor(inverted, cv2.COLOR_GRAY2BGR)
 
 
-def denoise(frame: np.ndarray) -> np.ndarray:
-    """Reduce sensor noise while keeping edges crisp for subsequent filters."""
-
-    if frame is None or frame.ndim != 3:
-        return frame
-
-    # fastNlMeansDenoisingColored preserves colours and edges better than a
-    # simple blur and helps stabilise later edge detection.
-    denoised = cv2.fastNlMeansDenoisingColored(frame, None, 10, 10, 7, 21)
-    return denoised
-
-
-def canny_edges(
-    frame: np.ndarray,
-    thresholds: Tuple[int, int] = (60, 180),
+def canny_from_inverted(
+    frame: np.ndarray, thresholds: Tuple[int, int] = (60, 180)
 ) -> np.ndarray:
-    """Return the Canny edge map of *frame* as a 3-channel image."""
+    """Compute a black and white Canny edge map from an inverted image."""
 
-    if frame is None or frame.ndim != 3:
+    if frame is None:
         return frame
 
-    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-    blurred = cv2.GaussianBlur(gray, (5, 5), 1.2)
-    edges = cv2.Canny(blurred, thresholds[0], thresholds[1])
-    return cv2.cvtColor(edges, cv2.COLOR_GRAY2BGR)
+    if frame.ndim == 3:
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    elif frame.ndim == 2:
+        gray = frame
+    else:
+        return frame
 
+    edges = cv2.Canny(gray, thresholds[0], thresholds[1])
+    return cv2.cvtColor(edges, cv2.COLOR_GRAY2BGR)

--- a/filters.py
+++ b/filters.py
@@ -32,6 +32,40 @@ def invert(frame: np.ndarray) -> np.ndarray:
     return inverted_bgr
 
 
+def merge_inverted_canny(
+    inverted_primary: np.ndarray | None,
+    inverted_secondary: np.ndarray | None = None,
+) -> np.ndarray | None:
+    """Return the combined Canny edges from two inverted views as a BGR frame.
+
+    The function expects the already inverted views of camera 0 and camera 1.
+    Both frames are converted to grayscale, passed through Canny edge detection,
+    and merged with a bitwise OR operation. The resulting edge map is converted
+    back to BGR so it can be displayed within the GUI alongside other views.
+    If the secondary view is unavailable, only the primary edges are returned.
+    """
+
+    if inverted_primary is None or inverted_primary.ndim != 3:
+        return None
+
+    height, width = inverted_primary.shape[:2]
+    primary_gray = cv2.cvtColor(inverted_primary, cv2.COLOR_BGR2GRAY)
+    primary_edges = cv2.Canny(primary_gray, 60, 180)
+
+    combined_edges = primary_edges
+
+    if inverted_secondary is not None and inverted_secondary.ndim == 3:
+        if inverted_secondary.shape[:2] != (height, width):
+            resized_secondary = cv2.resize(inverted_secondary, (width, height))
+        else:
+            resized_secondary = inverted_secondary
+        secondary_gray = cv2.cvtColor(resized_secondary, cv2.COLOR_BGR2GRAY)
+        secondary_edges = cv2.Canny(secondary_gray, 60, 180)
+        combined_edges = cv2.bitwise_or(primary_edges, secondary_edges)
+
+    return cv2.cvtColor(combined_edges, cv2.COLOR_GRAY2BGR)
+
+
 def _fit_circle_least_squares(points: np.ndarray) -> Tuple[float, float, float]:
     """Return the centre and radius of the least-squares circle through *points*."""
 

--- a/filters.py
+++ b/filters.py
@@ -82,51 +82,24 @@ def _select_dominant_radius(
     return selected, average_radius
 
 
-def _refine_ring_points(
-    points: np.ndarray, max_iterations: int = 5
-) -> Tuple[np.ndarray, Tuple[float, float, float]]:
-    """Iteratively remove outliers until the circle fit stabilises."""
+def detect_small_circles(
+    frame: np.ndarray,
+    inverted_primary: np.ndarray | None = None,
+    inverted_secondary: np.ndarray | None = None,
+) -> np.ndarray:
+    """Combine inverted feeds and Canny edges to detect flange geometry.
 
-    active_mask = np.ones(len(points), dtype=bool)
-    circle_parameters: Tuple[float, float, float] | None = None
+    The filter operates on camera 0 and expects the original frame together with
+    the inverted representations of camera 0 and camera 1. Both inverted views
+    are converted to grayscale, merged, and processed using a Canny edge
+    detector. The resulting edge map is searched for two circle populations:
 
-    for _ in range(max_iterations):
-        active_indices = np.flatnonzero(active_mask)
-        if len(active_indices) < 4:
-            break
+    * the largest outer circle representing the flange and
+    * at least three similarly sized circles representing the bolt holes.
 
-        cx, cy, radius = _fit_circle_least_squares(points[active_indices])
-        circle_parameters = (cx, cy, radius)
-
-        distances = np.linalg.norm(points[active_indices] - np.array([cx, cy]), axis=1)
-        deviation = np.abs(distances - radius)
-        allowed_deviation = max(3.0, 0.08 * radius)
-        keep_mask = deviation <= allowed_deviation
-        if np.all(keep_mask):
-            break
-
-        # Remove outliers from the active set and repeat.
-        active_mask[active_indices[~keep_mask]] = False
-
-    if circle_parameters is None:
-        raise ValueError("Unable to fit circle to the provided points")
-
-    final_indices = np.flatnonzero(active_mask)
-    if len(final_indices) >= 3:
-        cx, cy, radius = _fit_circle_least_squares(points[final_indices])
-        circle_parameters = (cx, cy, radius)
-
-    return final_indices, circle_parameters
-
-
-def detect_small_circles(frame: np.ndarray) -> np.ndarray:
-    """Detect flange patterns consisting of a large circle and bolt holes.
-
-    The filter searches for 4-18 small circles with a shared radius that lie on a
-    common mid-circle. If such a constellation is found, the average radius of the
-    small circles is used to render the detections. The outer flange diameter is
-    derived from the same centre so that only consistent geometries are
-    highlighted.
+    All confirmed bolt holes are rendered with the averaged radius of the
+    dominant cluster. The detected flange outline and the fitted mid-circle are
+    annotated together with a small preview of the combined Canny edge map.
     """
 
     if frame is None or frame.ndim != 3:
@@ -134,20 +107,45 @@ def detect_small_circles(frame: np.ndarray) -> np.ndarray:
 
     output = frame.copy()
 
-    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-    gray = cv2.medianBlur(gray, 5)
-    gray = cv2.equalizeHist(gray)
+    if inverted_primary is None or inverted_secondary is None:
+        cv2.putText(
+            output,
+            "Invertierte Ansichten fehlen",
+            (10, 30),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (0, 0, 255),
+            2,
+            cv2.LINE_AA,
+        )
+        return output
 
-    # Detect candidate screw holes.
+    height, width = frame.shape[:2]
+
+    if inverted_primary.shape[:2] != (height, width):
+        inverted_primary = cv2.resize(inverted_primary, (width, height))
+    if inverted_secondary.shape[:2] != (height, width):
+        inverted_secondary = cv2.resize(inverted_secondary, (width, height))
+
+    gray_primary = cv2.cvtColor(inverted_primary, cv2.COLOR_BGR2GRAY)
+    gray_secondary = cv2.cvtColor(inverted_secondary, cv2.COLOR_BGR2GRAY)
+
+    edges_primary = cv2.Canny(gray_primary, 60, 180)
+    edges_secondary = cv2.Canny(gray_secondary, 60, 180)
+    combined_edges = cv2.bitwise_or(edges_primary, edges_secondary)
+
+    blurred_edges = cv2.GaussianBlur(combined_edges, (7, 7), 1.5)
+
+    max_small_radius = max(6, int(round(min(height, width) * 0.12)))
     small_circle_candidates = cv2.HoughCircles(
-        gray,
+        blurred_edges,
         cv2.HOUGH_GRADIENT,
         dp=1.2,
         minDist=12,
-        param1=180,
-        param2=18,
+        param1=160,
+        param2=10,
         minRadius=3,
-        maxRadius=45,
+        maxRadius=max_small_radius,
     )
 
     if small_circle_candidates is None:
@@ -166,10 +164,10 @@ def detect_small_circles(frame: np.ndarray) -> np.ndarray:
     circles = np.round(small_circle_candidates[0]).astype(int)
     circles_list = [(int(x), int(y), int(r)) for x, y, r in circles]
 
-    if len(circles_list) < 4:
+    if len(circles_list) < 3:
         cv2.putText(
             output,
-            "Nicht genügend Schraubenlöcher",
+            "Mindestens 3 Löcher benötigt",
             (10, 30),
             cv2.FONT_HERSHEY_SIMPLEX,
             0.6,
@@ -179,14 +177,15 @@ def detect_small_circles(frame: np.ndarray) -> np.ndarray:
         )
         return output
 
-    dedup_radius = max(4.0, float(np.median([c[2] for c in circles_list])) * 0.6)
+    median_radius = float(np.median([c[2] for c in circles_list]))
+    dedup_radius = max(4.0, 0.6 * median_radius)
     merged_circles = _deduplicate_circles(circles_list, dedup_radius)
 
     selected_circles, avg_small_radius = _select_dominant_radius(merged_circles)
-    if len(selected_circles) < 4 or len(selected_circles) > 18:
+    if len(selected_circles) < 3:
         cv2.putText(
             output,
-            "Kein konsistenter Schraubenloch-Kreis",
+            "Keine stabile Lochgruppe",
             (10, 30),
             cv2.FONT_HERSHEY_SIMPLEX,
             0.6,
@@ -196,112 +195,71 @@ def detect_small_circles(frame: np.ndarray) -> np.ndarray:
         )
         return output
 
-    centers = np.array([(float(x), float(y)) for x, y, _ in selected_circles], dtype=np.float32)
+    normalised_radius = max(1, int(round(avg_small_radius)))
+
+    centres = np.array([(float(x), float(y)) for x, y, _ in selected_circles], dtype=np.float32)
     try:
-        inlier_indices, (mid_cx, mid_cy, mid_radius) = _refine_ring_points(centers)
+        mid_cx, mid_cy, mid_radius = _fit_circle_least_squares(centres)
     except ValueError:
-        cv2.putText(
-            output,
-            "Mittlerer Kreis konnte nicht bestimmt werden",
-            (10, 30),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.6,
-            (0, 0, 255),
-            2,
-            cv2.LINE_AA,
-        )
-        return output
+        mid_cx = float(np.mean(centres[:, 0]))
+        mid_cy = float(np.mean(centres[:, 1]))
+        radial_distances = np.linalg.norm(centres - np.array([mid_cx, mid_cy]), axis=1)
+        mid_radius = float(np.mean(radial_distances)) if radial_distances.size else float(normalised_radius)
 
-    if len(inlier_indices) < 4 or len(inlier_indices) > 18:
-        cv2.putText(
-            output,
-            "Zu wenige/zu viele Schraubenlöcher",
-            (10, 30),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.6,
-            (0, 0, 255),
-            2,
-            cv2.LINE_AA,
-        )
-        return output
+    outer_min_radius = max(
+        30,
+        int(round(mid_radius + avg_small_radius * 1.5)),
+        max_small_radius * 2,
+    )
+    outer_max_radius = int(round(min(math.hypot(width, height) / 2.0, min(height, width) * 0.95)))
 
-    inlier_circles = [selected_circles[int(idx)] for idx in inlier_indices]
-    inlier_centers = centers[inlier_indices]
-
-    # Validate the angular distribution to suppress false positives.
-    vectors = inlier_centers - np.array([mid_cx, mid_cy])
-    angles = np.degrees(np.arctan2(vectors[:, 1], vectors[:, 0]))
-    angles = np.sort((angles + 360.0) % 360.0)
-    diffs = np.diff(np.concatenate([angles, angles[:1] + 360.0]))
-    min_sep = float(diffs.min()) if len(diffs) else 360.0
-    coverage = 360.0 - float(diffs.max()) if len(diffs) else 0.0
-
-    if min_sep < 10.0 or coverage < 180.0:
-        cv2.putText(
-            output,
-            "Schraubenlöcher nicht rund verteilt",
-            (10, 30),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.6,
-            (0, 0, 255),
-            2,
-            cv2.LINE_AA,
-        )
-        return output
-
-    avg_small_radius = float(np.mean([c[2] for c in inlier_circles]))
-    normalised_radius = int(round(avg_small_radius))
-
-    # Determine the flange diameter (outer circle) close to the fitted centre.
     flange_circle = None
-    min_outer_radius = int(round(mid_radius + avg_small_radius * 1.2))
-    max_outer_radius = int(round(mid_radius * 1.9 + avg_small_radius))
-    if max_outer_radius > min_outer_radius + 2:
+    if outer_max_radius > outer_min_radius:
         large_circle_candidates = cv2.HoughCircles(
-            gray,
+            blurred_edges,
             cv2.HOUGH_GRADIENT,
-            dp=1.0,
-            minDist=max(30, int(mid_radius * 0.5)),
-            param1=200,
-            param2=60,
-            minRadius=min_outer_radius,
-            maxRadius=max_outer_radius,
+            dp=1.1,
+            minDist=max(40, int(round(mid_radius))),
+            param1=180,
+            param2=25,
+            minRadius=outer_min_radius,
+            maxRadius=outer_max_radius,
         )
         if large_circle_candidates is not None:
             candidate_list = np.round(large_circle_candidates[0]).astype(int)
-            filtered_candidates = []
-            for x, y, r in candidate_list:
-                if r <= min_outer_radius:
-                    continue
-                center_distance = math.hypot(x - mid_cx, y - mid_cy)
-                if center_distance > max(20.0, 0.2 * mid_radius):
-                    continue
-                filtered_candidates.append((x, y, r))
-
-            if filtered_candidates:
-                flange_circle = max(filtered_candidates, key=lambda c: c[2])
+            sorted_candidates = sorted(
+                [(int(x), int(y), int(r)) for x, y, r in candidate_list],
+                key=lambda c: c[2],
+                reverse=True,
+            )
+            for candidate in sorted_candidates:
+                distance = math.hypot(candidate[0] - mid_cx, candidate[1] - mid_cy)
+                if distance <= max(30.0, 0.25 * max(mid_radius, 1.0)):
+                    flange_circle = candidate
+                    break
+            if flange_circle is None and sorted_candidates:
+                flange_circle = sorted_candidates[0]
 
     if flange_circle is None:
         flange_circle = (
             int(round(mid_cx)),
             int(round(mid_cy)),
-            int(round(mid_radius + avg_small_radius * 1.6)),
+            int(round(mid_radius + avg_small_radius * 2.2)),
         )
 
     flange_cx, flange_cy, flange_radius = flange_circle
 
-    # Draw flange and mid-circle.
     cv2.circle(output, (flange_cx, flange_cy), flange_radius, (255, 0, 0), 2)
     cv2.circle(output, (int(round(mid_cx)), int(round(mid_cy))), int(round(mid_radius)), (0, 255, 255), 1)
     cv2.circle(output, (int(round(mid_cx)), int(round(mid_cy))), 3, (0, 0, 255), -1)
 
-    for x, y, _ in inlier_circles:
+    for x, y, _ in selected_circles:
         cv2.circle(output, (int(x), int(y)), normalised_radius, (0, 255, 0), 2)
         cv2.circle(output, (int(x), int(y)), 2, (0, 255, 0), -1)
 
     cv2.putText(
         output,
-        f"Loecher: {len(inlier_circles)}  r={normalised_radius}px",
+        f"Loecher: {len(selected_circles)}  r={normalised_radius}px",
         (10, 30),
         cv2.FONT_HERSHEY_SIMPLEX,
         0.6,
@@ -311,13 +269,57 @@ def detect_small_circles(frame: np.ndarray) -> np.ndarray:
     )
     cv2.putText(
         output,
-        f"Mittenkreis: {int(round(mid_radius))}px  Flansch: {flange_radius}px",
+        f"Flansch: {flange_radius}px  Mitte: {int(round(mid_radius))}px",
         (10, 55),
         cv2.FONT_HERSHEY_SIMPLEX,
         0.6,
-        (0, 255, 255),
+        (255, 255, 0),
         2,
         cv2.LINE_AA,
     )
+    cv2.putText(
+        output,
+        "Basis: invertiert + Canny (Cam0+1)",
+        (10, 80),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.5,
+        (200, 200, 200),
+        1,
+        cv2.LINE_AA,
+    )
+
+    preview_height = min(120, max(30, height // 3))
+    preview_width = max(30, int(round(preview_height * width / max(height, 1))))
+    preview_width = min(preview_width, max(30, width - 20))
+    if (
+        preview_height > 0
+        and preview_width > 0
+        and preview_height + 20 < height
+        and preview_width + 20 < width
+    ):
+        preview_edges = cv2.resize(combined_edges, (preview_width, preview_height))
+        preview_bgr = cv2.cvtColor(preview_edges, cv2.COLOR_GRAY2BGR)
+        y0 = height - preview_height - 10
+        x0 = width - preview_width - 10
+        roi = output[y0 : y0 + preview_height, x0 : x0 + preview_width]
+        blended = cv2.addWeighted(preview_bgr, 0.6, roi, 0.4, 0.0)
+        output[y0 : y0 + preview_height, x0 : x0 + preview_width] = blended
+        cv2.rectangle(
+            output,
+            (x0, y0),
+            (x0 + preview_width, y0 + preview_height),
+            (0, 255, 255),
+            1,
+        )
+        cv2.putText(
+            output,
+            "Canny Merge",
+            (x0 + 5, y0 + preview_height - 8),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.4,
+            (0, 255, 255),
+            1,
+            cv2.LINE_AA,
+        )
 
     return output

--- a/filters.py
+++ b/filters.py
@@ -1,6 +1,9 @@
 """Image processing filters for camera frames."""
 from __future__ import annotations
 
+import math
+from typing import List, Sequence, Tuple
+
 import cv2
 import numpy as np
 
@@ -29,15 +32,101 @@ def invert(frame: np.ndarray) -> np.ndarray:
     return inverted_bgr
 
 
-def detect_small_circles(frame: np.ndarray) -> np.ndarray:
-    """Detect and visualize circular features with normalized radii.
+def _fit_circle_least_squares(points: np.ndarray) -> Tuple[float, float, float]:
+    """Return the centre and radius of the least-squares circle through *points*."""
 
-    The filter highlights the largest circles in the scene and analyses the
-    remaining detections for groups of similarly sized circles. When at least
-    three circles with comparable radii are found, their mean radius is used to
-    render all non-maximal circles with a consistent size. The intention is to
-    stabilise the visualisation of the small circular holes in the workpiece
-    despite noisy detections.
+    if len(points) < 3:
+        raise ValueError("At least three points are required to fit a circle")
+
+    # Solve the linearised circle equation: x^2 + y^2 = 2ax + 2by + c
+    a_matrix = np.hstack((2.0 * points, np.ones((points.shape[0], 1))))
+    b_vector = np.sum(points ** 2, axis=1)
+    solution, *_ = np.linalg.lstsq(a_matrix, b_vector, rcond=None)
+    cx, cy, c_term = solution
+    radius_sq = c_term + cx * cx + cy * cy
+    radius = math.sqrt(max(radius_sq, 0.0))
+    return float(cx), float(cy), float(radius)
+
+
+def _deduplicate_circles(
+    circles: Sequence[Tuple[int, int, int]],
+    min_center_distance: float,
+) -> List[Tuple[int, int, int]]:
+    """Merge detections that share (almost) the same centre."""
+
+    merged: List[Tuple[int, int, int]] = []
+    for x, y, radius in sorted(circles, key=lambda c: c[2], reverse=True):
+        if all(np.hypot(x - mx, y - my) >= min_center_distance for mx, my, _ in merged):
+            merged.append((x, y, radius))
+    return merged
+
+
+def _select_dominant_radius(
+    circles: Sequence[Tuple[int, int, int]]
+) -> Tuple[List[Tuple[int, int, int]], float]:
+    """Return circles that share the dominant radius and the average radius."""
+
+    if not circles:
+        return [], 0.0
+
+    radii = np.array([c[2] for c in circles], dtype=np.float32)
+    median_radius = float(np.median(radii))
+    radius_tolerance = max(2.0, 0.25 * median_radius)
+    selected = [
+        circle for circle in circles if abs(circle[2] - median_radius) <= radius_tolerance
+    ]
+    if not selected:
+        return [], 0.0
+
+    average_radius = float(np.mean([c[2] for c in selected]))
+    return selected, average_radius
+
+
+def _refine_ring_points(
+    points: np.ndarray, max_iterations: int = 5
+) -> Tuple[np.ndarray, Tuple[float, float, float]]:
+    """Iteratively remove outliers until the circle fit stabilises."""
+
+    active_mask = np.ones(len(points), dtype=bool)
+    circle_parameters: Tuple[float, float, float] | None = None
+
+    for _ in range(max_iterations):
+        active_indices = np.flatnonzero(active_mask)
+        if len(active_indices) < 4:
+            break
+
+        cx, cy, radius = _fit_circle_least_squares(points[active_indices])
+        circle_parameters = (cx, cy, radius)
+
+        distances = np.linalg.norm(points[active_indices] - np.array([cx, cy]), axis=1)
+        deviation = np.abs(distances - radius)
+        allowed_deviation = max(3.0, 0.08 * radius)
+        keep_mask = deviation <= allowed_deviation
+        if np.all(keep_mask):
+            break
+
+        # Remove outliers from the active set and repeat.
+        active_mask[active_indices[~keep_mask]] = False
+
+    if circle_parameters is None:
+        raise ValueError("Unable to fit circle to the provided points")
+
+    final_indices = np.flatnonzero(active_mask)
+    if len(final_indices) >= 3:
+        cx, cy, radius = _fit_circle_least_squares(points[final_indices])
+        circle_parameters = (cx, cy, radius)
+
+    return final_indices, circle_parameters
+
+
+def detect_small_circles(frame: np.ndarray) -> np.ndarray:
+    """Detect flange patterns consisting of a large circle and bolt holes.
+
+    The filter searches for 4-18 small circles with a shared radius that lie on a
+    common mid-circle. If such a constellation is found, the average radius of the
+    small circles is used to render the detections. The outer flange diameter is
+    derived from the same centre so that only consistent geometries are
+    highlighted.
     """
 
     if frame is None or frame.ndim != 3:
@@ -46,104 +135,189 @@ def detect_small_circles(frame: np.ndarray) -> np.ndarray:
     output = frame.copy()
 
     gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-    blurred = cv2.GaussianBlur(gray, (9, 9), 2.0)
+    gray = cv2.medianBlur(gray, 5)
+    gray = cv2.equalizeHist(gray)
 
-    circles = cv2.HoughCircles(
-        blurred,
+    # Detect candidate screw holes.
+    small_circle_candidates = cv2.HoughCircles(
+        gray,
         cv2.HOUGH_GRADIENT,
         dp=1.2,
-        minDist=20,
-        param1=120,
-        param2=35,
-        minRadius=5,
-        maxRadius=0,
+        minDist=12,
+        param1=180,
+        param2=18,
+        minRadius=3,
+        maxRadius=45,
     )
 
-    if circles is None or not len(circles):
-        return output
-
-    circles = np.round(circles[0]).astype(int)
-    circle_list = [(int(x), int(y), int(r)) for x, y, r in circles]
-    circle_list.sort(key=lambda c: c[2], reverse=True)
-
-    largest_radius = circle_list[0][2]
-    large_threshold = max(5, int(largest_radius * 0.8))
-    large_circles = [c for c in circle_list if c[2] >= large_threshold]
-    large_circle_set = {tuple(c) for c in large_circles}
-
-    groups = []
-    for circle in circle_list:
-        if tuple(circle) in large_circle_set:
-            continue
-        radius = circle[2]
-        placed = False
-        for group in groups:
-            tolerance = max(2.0, 0.08 * group["mean_radius"])
-            if abs(group["mean_radius"] - radius) <= tolerance:
-                group["members"].append(circle)
-                group["mean_radius"] = float(
-                    np.mean([member[2] for member in group["members"]])
-                )
-                placed = True
-                break
-        if not placed:
-            groups.append({"mean_radius": float(radius), "members": [circle]})
-
-    repeated_group = None
-    for group in groups:
-        if len(group["members"]) < 3:
-            continue
-        if repeated_group is None:
-            repeated_group = group
-            continue
-        if len(group["members"]) > len(repeated_group["members"]):
-            repeated_group = group
-            continue
-        if (
-            len(group["members"]) == len(repeated_group["members"])
-            and group["mean_radius"] < repeated_group["mean_radius"]
-        ):
-            repeated_group = group
-
-    normalised_radius = None
-    if repeated_group is not None:
-        normalised_radius = int(round(repeated_group["mean_radius"]))
-
-    small_candidates = [
-        circle for circle in circle_list if tuple(circle) not in large_circle_set
-    ]
-
-    for x, y, radius in large_circles:
-        cv2.circle(output, (x, y), radius, (255, 0, 0), 2)
-        cv2.circle(output, (x, y), 2, (255, 0, 0), 3)
-
-    if normalised_radius is not None:
-        for x, y, _ in small_candidates:
-            cv2.circle(output, (x, y), normalised_radius, (0, 255, 0), 2)
-            cv2.circle(output, (x, y), 2, (0, 255, 0), 3)
+    if small_circle_candidates is None:
         cv2.putText(
             output,
-            f"Mittelradius: {normalised_radius}px",
+            "Keine Schraubenlöcher erkannt",
             (10, 30),
             cv2.FONT_HERSHEY_SIMPLEX,
-            0.7,
-            (0, 255, 0),
+            0.6,
+            (0, 0, 255),
             2,
             cv2.LINE_AA,
         )
-    else:
-        for x, y, radius in small_candidates:
-            cv2.circle(output, (x, y), radius, (0, 255, 255), 1)
-            cv2.circle(output, (x, y), 2, (0, 255, 255), 3)
+        return output
+
+    circles = np.round(small_circle_candidates[0]).astype(int)
+    circles_list = [(int(x), int(y), int(r)) for x, y, r in circles]
+
+    if len(circles_list) < 4:
         cv2.putText(
             output,
-            "Nicht genug gleich große Kreise gefunden",
+            "Nicht genügend Schraubenlöcher",
             (10, 30),
             cv2.FONT_HERSHEY_SIMPLEX,
-            0.5,
+            0.6,
             (0, 0, 255),
-            1,
+            2,
             cv2.LINE_AA,
         )
+        return output
+
+    dedup_radius = max(4.0, float(np.median([c[2] for c in circles_list])) * 0.6)
+    merged_circles = _deduplicate_circles(circles_list, dedup_radius)
+
+    selected_circles, avg_small_radius = _select_dominant_radius(merged_circles)
+    if len(selected_circles) < 4 or len(selected_circles) > 18:
+        cv2.putText(
+            output,
+            "Kein konsistenter Schraubenloch-Kreis",
+            (10, 30),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (0, 0, 255),
+            2,
+            cv2.LINE_AA,
+        )
+        return output
+
+    centers = np.array([(float(x), float(y)) for x, y, _ in selected_circles], dtype=np.float32)
+    try:
+        inlier_indices, (mid_cx, mid_cy, mid_radius) = _refine_ring_points(centers)
+    except ValueError:
+        cv2.putText(
+            output,
+            "Mittlerer Kreis konnte nicht bestimmt werden",
+            (10, 30),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (0, 0, 255),
+            2,
+            cv2.LINE_AA,
+        )
+        return output
+
+    if len(inlier_indices) < 4 or len(inlier_indices) > 18:
+        cv2.putText(
+            output,
+            "Zu wenige/zu viele Schraubenlöcher",
+            (10, 30),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (0, 0, 255),
+            2,
+            cv2.LINE_AA,
+        )
+        return output
+
+    inlier_circles = [selected_circles[int(idx)] for idx in inlier_indices]
+    inlier_centers = centers[inlier_indices]
+
+    # Validate the angular distribution to suppress false positives.
+    vectors = inlier_centers - np.array([mid_cx, mid_cy])
+    angles = np.degrees(np.arctan2(vectors[:, 1], vectors[:, 0]))
+    angles = np.sort((angles + 360.0) % 360.0)
+    diffs = np.diff(np.concatenate([angles, angles[:1] + 360.0]))
+    min_sep = float(diffs.min()) if len(diffs) else 360.0
+    coverage = 360.0 - float(diffs.max()) if len(diffs) else 0.0
+
+    if min_sep < 10.0 or coverage < 180.0:
+        cv2.putText(
+            output,
+            "Schraubenlöcher nicht rund verteilt",
+            (10, 30),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (0, 0, 255),
+            2,
+            cv2.LINE_AA,
+        )
+        return output
+
+    avg_small_radius = float(np.mean([c[2] for c in inlier_circles]))
+    normalised_radius = int(round(avg_small_radius))
+
+    # Determine the flange diameter (outer circle) close to the fitted centre.
+    flange_circle = None
+    min_outer_radius = int(round(mid_radius + avg_small_radius * 1.2))
+    max_outer_radius = int(round(mid_radius * 1.9 + avg_small_radius))
+    if max_outer_radius > min_outer_radius + 2:
+        large_circle_candidates = cv2.HoughCircles(
+            gray,
+            cv2.HOUGH_GRADIENT,
+            dp=1.0,
+            minDist=max(30, int(mid_radius * 0.5)),
+            param1=200,
+            param2=60,
+            minRadius=min_outer_radius,
+            maxRadius=max_outer_radius,
+        )
+        if large_circle_candidates is not None:
+            candidate_list = np.round(large_circle_candidates[0]).astype(int)
+            filtered_candidates = []
+            for x, y, r in candidate_list:
+                if r <= min_outer_radius:
+                    continue
+                center_distance = math.hypot(x - mid_cx, y - mid_cy)
+                if center_distance > max(20.0, 0.2 * mid_radius):
+                    continue
+                filtered_candidates.append((x, y, r))
+
+            if filtered_candidates:
+                flange_circle = max(filtered_candidates, key=lambda c: c[2])
+
+    if flange_circle is None:
+        flange_circle = (
+            int(round(mid_cx)),
+            int(round(mid_cy)),
+            int(round(mid_radius + avg_small_radius * 1.6)),
+        )
+
+    flange_cx, flange_cy, flange_radius = flange_circle
+
+    # Draw flange and mid-circle.
+    cv2.circle(output, (flange_cx, flange_cy), flange_radius, (255, 0, 0), 2)
+    cv2.circle(output, (int(round(mid_cx)), int(round(mid_cy))), int(round(mid_radius)), (0, 255, 255), 1)
+    cv2.circle(output, (int(round(mid_cx)), int(round(mid_cy))), 3, (0, 0, 255), -1)
+
+    for x, y, _ in inlier_circles:
+        cv2.circle(output, (int(x), int(y)), normalised_radius, (0, 255, 0), 2)
+        cv2.circle(output, (int(x), int(y)), 2, (0, 255, 0), -1)
+
+    cv2.putText(
+        output,
+        f"Loecher: {len(inlier_circles)}  r={normalised_radius}px",
+        (10, 30),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.6,
+        (0, 255, 0),
+        2,
+        cv2.LINE_AA,
+    )
+    cv2.putText(
+        output,
+        f"Mittenkreis: {int(round(mid_radius))}px  Flansch: {flange_radius}px",
+        (10, 55),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.6,
+        (0, 255, 255),
+        2,
+        cv2.LINE_AA,
+    )
 
     return output

--- a/filters.py
+++ b/filters.py
@@ -1,29 +1,28 @@
 """Image processing filters for camera frames."""
 from __future__ import annotations
 
-import math
-from typing import List, Sequence, Tuple
+from typing import Tuple
 
 import cv2
 import numpy as np
 
 
 def invert(frame: np.ndarray) -> np.ndarray:
-    """Return a grayscale-inverted frame with red contours highlighting edges.
+    """Return a grayscale-inverted frame with edge highlights.
 
-    The input frame is converted to grayscale, inverted, and then converted
-    back to a 3-channel image so it can be rendered alongside color frames in
-    the GUI. Canny edge detection is used to extract the dominant geometry and
-    the detected contours are traced with a red outline for better visibility.
+    The input frame is converted to grayscale, inverted and converted back to
+    BGR so it can be rendered alongside the colour streams in the GUI. Canny
+    edges are detected on the original luminance channel and drawn in red to
+    improve the visibility of structural features.
     """
-    # Convert to grayscale to ensure the inversion only affects luminance.
-    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
 
-    # Invert the grayscale image and convert it back to BGR for display.
+    if frame is None or frame.ndim != 3:
+        return frame
+
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
     inverted_gray = cv2.bitwise_not(gray)
     inverted_bgr = cv2.cvtColor(inverted_gray, cv2.COLOR_GRAY2BGR)
 
-    # Detect edges and outline their contours in red to highlight geometry.
     edges = cv2.Canny(gray, 100, 200)
     contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
     if contours:
@@ -32,328 +31,29 @@ def invert(frame: np.ndarray) -> np.ndarray:
     return inverted_bgr
 
 
-def merge_inverted_canny(
-    inverted_primary: np.ndarray | None,
-    inverted_secondary: np.ndarray | None = None,
-) -> np.ndarray | None:
-    """Return the combined Canny edges from two inverted views as a BGR frame.
-
-    The function expects the already inverted views of camera 0 and camera 1.
-    Both frames are converted to grayscale, passed through Canny edge detection,
-    and merged with a bitwise OR operation. The resulting edge map is converted
-    back to BGR so it can be displayed within the GUI alongside other views.
-    If the secondary view is unavailable, only the primary edges are returned.
-    """
-
-    if inverted_primary is None or inverted_primary.ndim != 3:
-        return None
-
-    height, width = inverted_primary.shape[:2]
-    primary_gray = cv2.cvtColor(inverted_primary, cv2.COLOR_BGR2GRAY)
-    primary_edges = cv2.Canny(primary_gray, 60, 180)
-
-    combined_edges = primary_edges
-
-    if inverted_secondary is not None and inverted_secondary.ndim == 3:
-        if inverted_secondary.shape[:2] != (height, width):
-            resized_secondary = cv2.resize(inverted_secondary, (width, height))
-        else:
-            resized_secondary = inverted_secondary
-        secondary_gray = cv2.cvtColor(resized_secondary, cv2.COLOR_BGR2GRAY)
-        secondary_edges = cv2.Canny(secondary_gray, 60, 180)
-        combined_edges = cv2.bitwise_or(primary_edges, secondary_edges)
-
-    return cv2.cvtColor(combined_edges, cv2.COLOR_GRAY2BGR)
-
-
-def _fit_circle_least_squares(points: np.ndarray) -> Tuple[float, float, float]:
-    """Return the centre and radius of the least-squares circle through *points*."""
-
-    if len(points) < 3:
-        raise ValueError("At least three points are required to fit a circle")
-
-    # Solve the linearised circle equation: x^2 + y^2 = 2ax + 2by + c
-    a_matrix = np.hstack((2.0 * points, np.ones((points.shape[0], 1))))
-    b_vector = np.sum(points ** 2, axis=1)
-    solution, *_ = np.linalg.lstsq(a_matrix, b_vector, rcond=None)
-    cx, cy, c_term = solution
-    radius_sq = c_term + cx * cx + cy * cy
-    radius = math.sqrt(max(radius_sq, 0.0))
-    return float(cx), float(cy), float(radius)
-
-
-def _deduplicate_circles(
-    circles: Sequence[Tuple[int, int, int]],
-    min_center_distance: float,
-) -> List[Tuple[int, int, int]]:
-    """Merge detections that share (almost) the same centre."""
-
-    merged: List[Tuple[int, int, int]] = []
-    for x, y, radius in sorted(circles, key=lambda c: c[2], reverse=True):
-        if all(np.hypot(x - mx, y - my) >= min_center_distance for mx, my, _ in merged):
-            merged.append((x, y, radius))
-    return merged
-
-
-def _select_dominant_radius(
-    circles: Sequence[Tuple[int, int, int]]
-) -> Tuple[List[Tuple[int, int, int]], float]:
-    """Return circles that share the dominant radius and the average radius."""
-
-    if not circles:
-        return [], 0.0
-
-    radii = np.array([c[2] for c in circles], dtype=np.float32)
-    median_radius = float(np.median(radii))
-    radius_tolerance = max(2.0, 0.25 * median_radius)
-    selected = [
-        circle for circle in circles if abs(circle[2] - median_radius) <= radius_tolerance
-    ]
-    if not selected:
-        return [], 0.0
-
-    average_radius = float(np.mean([c[2] for c in selected]))
-    return selected, average_radius
-
-
-def detect_small_circles(
-    frame: np.ndarray,
-    inverted_primary: np.ndarray | None = None,
-    inverted_secondary: np.ndarray | None = None,
-) -> np.ndarray:
-    """Combine inverted feeds and Canny edges to detect flange geometry.
-
-    The filter operates on camera 0 and expects the original frame together with
-    the inverted representations of camera 0 and camera 1. Both inverted views
-    are converted to grayscale, merged, and processed using a Canny edge
-    detector. The resulting edge map is searched for two circle populations:
-
-    * the largest outer circle representing the flange and
-    * at least three similarly sized circles representing the bolt holes.
-
-    All confirmed bolt holes are rendered with the averaged radius of the
-    dominant cluster. The detected flange outline and the fitted mid-circle are
-    annotated together with a small preview of the combined Canny edge map.
-    """
+def denoise(frame: np.ndarray) -> np.ndarray:
+    """Reduce sensor noise while keeping edges crisp for subsequent filters."""
 
     if frame is None or frame.ndim != 3:
         return frame
 
-    output = frame.copy()
+    # fastNlMeansDenoisingColored preserves colours and edges better than a
+    # simple blur and helps stabilise later edge detection.
+    denoised = cv2.fastNlMeansDenoisingColored(frame, None, 10, 10, 7, 21)
+    return denoised
 
-    if inverted_primary is None or inverted_secondary is None:
-        cv2.putText(
-            output,
-            "Invertierte Ansichten fehlen",
-            (10, 30),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.6,
-            (0, 0, 255),
-            2,
-            cv2.LINE_AA,
-        )
-        return output
 
-    height, width = frame.shape[:2]
+def canny_edges(
+    frame: np.ndarray,
+    thresholds: Tuple[int, int] = (60, 180),
+) -> np.ndarray:
+    """Return the Canny edge map of *frame* as a 3-channel image."""
 
-    if inverted_primary.shape[:2] != (height, width):
-        inverted_primary = cv2.resize(inverted_primary, (width, height))
-    if inverted_secondary.shape[:2] != (height, width):
-        inverted_secondary = cv2.resize(inverted_secondary, (width, height))
+    if frame is None or frame.ndim != 3:
+        return frame
 
-    gray_primary = cv2.cvtColor(inverted_primary, cv2.COLOR_BGR2GRAY)
-    gray_secondary = cv2.cvtColor(inverted_secondary, cv2.COLOR_BGR2GRAY)
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    blurred = cv2.GaussianBlur(gray, (5, 5), 1.2)
+    edges = cv2.Canny(blurred, thresholds[0], thresholds[1])
+    return cv2.cvtColor(edges, cv2.COLOR_GRAY2BGR)
 
-    edges_primary = cv2.Canny(gray_primary, 60, 180)
-    edges_secondary = cv2.Canny(gray_secondary, 60, 180)
-    combined_edges = cv2.bitwise_or(edges_primary, edges_secondary)
-
-    blurred_edges = cv2.GaussianBlur(combined_edges, (7, 7), 1.5)
-
-    max_small_radius = max(6, int(round(min(height, width) * 0.12)))
-    small_circle_candidates = cv2.HoughCircles(
-        blurred_edges,
-        cv2.HOUGH_GRADIENT,
-        dp=1.2,
-        minDist=12,
-        param1=160,
-        param2=10,
-        minRadius=3,
-        maxRadius=max_small_radius,
-    )
-
-    if small_circle_candidates is None:
-        cv2.putText(
-            output,
-            "Keine Schraubenlöcher erkannt",
-            (10, 30),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.6,
-            (0, 0, 255),
-            2,
-            cv2.LINE_AA,
-        )
-        return output
-
-    circles = np.round(small_circle_candidates[0]).astype(int)
-    circles_list = [(int(x), int(y), int(r)) for x, y, r in circles]
-
-    if len(circles_list) < 3:
-        cv2.putText(
-            output,
-            "Mindestens 3 Löcher benötigt",
-            (10, 30),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.6,
-            (0, 0, 255),
-            2,
-            cv2.LINE_AA,
-        )
-        return output
-
-    median_radius = float(np.median([c[2] for c in circles_list]))
-    dedup_radius = max(4.0, 0.6 * median_radius)
-    merged_circles = _deduplicate_circles(circles_list, dedup_radius)
-
-    selected_circles, avg_small_radius = _select_dominant_radius(merged_circles)
-    if len(selected_circles) < 3:
-        cv2.putText(
-            output,
-            "Keine stabile Lochgruppe",
-            (10, 30),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.6,
-            (0, 0, 255),
-            2,
-            cv2.LINE_AA,
-        )
-        return output
-
-    normalised_radius = max(1, int(round(avg_small_radius)))
-
-    centres = np.array([(float(x), float(y)) for x, y, _ in selected_circles], dtype=np.float32)
-    try:
-        mid_cx, mid_cy, mid_radius = _fit_circle_least_squares(centres)
-    except ValueError:
-        mid_cx = float(np.mean(centres[:, 0]))
-        mid_cy = float(np.mean(centres[:, 1]))
-        radial_distances = np.linalg.norm(centres - np.array([mid_cx, mid_cy]), axis=1)
-        mid_radius = float(np.mean(radial_distances)) if radial_distances.size else float(normalised_radius)
-
-    outer_min_radius = max(
-        30,
-        int(round(mid_radius + avg_small_radius * 1.5)),
-        max_small_radius * 2,
-    )
-    outer_max_radius = int(round(min(math.hypot(width, height) / 2.0, min(height, width) * 0.95)))
-
-    flange_circle = None
-    if outer_max_radius > outer_min_radius:
-        large_circle_candidates = cv2.HoughCircles(
-            blurred_edges,
-            cv2.HOUGH_GRADIENT,
-            dp=1.1,
-            minDist=max(40, int(round(mid_radius))),
-            param1=180,
-            param2=25,
-            minRadius=outer_min_radius,
-            maxRadius=outer_max_radius,
-        )
-        if large_circle_candidates is not None:
-            candidate_list = np.round(large_circle_candidates[0]).astype(int)
-            sorted_candidates = sorted(
-                [(int(x), int(y), int(r)) for x, y, r in candidate_list],
-                key=lambda c: c[2],
-                reverse=True,
-            )
-            for candidate in sorted_candidates:
-                distance = math.hypot(candidate[0] - mid_cx, candidate[1] - mid_cy)
-                if distance <= max(30.0, 0.25 * max(mid_radius, 1.0)):
-                    flange_circle = candidate
-                    break
-            if flange_circle is None and sorted_candidates:
-                flange_circle = sorted_candidates[0]
-
-    if flange_circle is None:
-        flange_circle = (
-            int(round(mid_cx)),
-            int(round(mid_cy)),
-            int(round(mid_radius + avg_small_radius * 2.2)),
-        )
-
-    flange_cx, flange_cy, flange_radius = flange_circle
-
-    cv2.circle(output, (flange_cx, flange_cy), flange_radius, (255, 0, 0), 2)
-    cv2.circle(output, (int(round(mid_cx)), int(round(mid_cy))), int(round(mid_radius)), (0, 255, 255), 1)
-    cv2.circle(output, (int(round(mid_cx)), int(round(mid_cy))), 3, (0, 0, 255), -1)
-
-    for x, y, _ in selected_circles:
-        cv2.circle(output, (int(x), int(y)), normalised_radius, (0, 255, 0), 2)
-        cv2.circle(output, (int(x), int(y)), 2, (0, 255, 0), -1)
-
-    cv2.putText(
-        output,
-        f"Loecher: {len(selected_circles)}  r={normalised_radius}px",
-        (10, 30),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        0.6,
-        (0, 255, 0),
-        2,
-        cv2.LINE_AA,
-    )
-    cv2.putText(
-        output,
-        f"Flansch: {flange_radius}px  Mitte: {int(round(mid_radius))}px",
-        (10, 55),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        0.6,
-        (255, 255, 0),
-        2,
-        cv2.LINE_AA,
-    )
-    cv2.putText(
-        output,
-        "Basis: invertiert + Canny (Cam0+1)",
-        (10, 80),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        0.5,
-        (200, 200, 200),
-        1,
-        cv2.LINE_AA,
-    )
-
-    preview_height = min(120, max(30, height // 3))
-    preview_width = max(30, int(round(preview_height * width / max(height, 1))))
-    preview_width = min(preview_width, max(30, width - 20))
-    if (
-        preview_height > 0
-        and preview_width > 0
-        and preview_height + 20 < height
-        and preview_width + 20 < width
-    ):
-        preview_edges = cv2.resize(combined_edges, (preview_width, preview_height))
-        preview_bgr = cv2.cvtColor(preview_edges, cv2.COLOR_GRAY2BGR)
-        y0 = height - preview_height - 10
-        x0 = width - preview_width - 10
-        roi = output[y0 : y0 + preview_height, x0 : x0 + preview_width]
-        blended = cv2.addWeighted(preview_bgr, 0.6, roi, 0.4, 0.0)
-        output[y0 : y0 + preview_height, x0 : x0 + preview_width] = blended
-        cv2.rectangle(
-            output,
-            (x0, y0),
-            (x0 + preview_width, y0 + preview_height),
-            (0, 255, 255),
-            1,
-        )
-        cv2.putText(
-            output,
-            "Canny Merge",
-            (x0 + 5, y0 + preview_height - 8),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.4,
-            (0, 255, 255),
-            1,
-            cv2.LINE_AA,
-        )
-
-    return output

--- a/gui.py
+++ b/gui.py
@@ -14,6 +14,11 @@ from tkinter import ttk
 
 from camera_capture import MultiCameraCapture
 from filters import canny_from_inverted, invert_grayscale
+from stereo_reconstruction import (
+    StereoReconstructor,
+    create_default_matcher,
+    load_calibration,
+)
 
 
 class DualInvertApp:
@@ -28,14 +33,26 @@ class DualInvertApp:
         self.root.title("Dual Kamera Ansicht mit Invertierung")
 
         self._camera_indices: List[int] = list(camera_indices)
-        self._capture = MultiCameraCapture(self._camera_indices)
+
+        self._stereo_renderer: Optional[StereoReconstructor] = None
+        self._stereo_status: Optional[str] = None
+        self._stereo_pair: Optional[Tuple[int, int]] = None
+        self._stereo_calibration_size: Optional[Tuple[int, int]] = None
+        self._load_stereo_configuration()
+
+        capture_frame_size = self._stereo_calibration_size or (640, 360)
+        self._capture = MultiCameraCapture(
+            self._camera_indices,
+            frame_size=capture_frame_size,
+        )
         self._photo_images: Dict[Tuple[int, str], tk.PhotoImage] = {}
         self._last_frames: Dict[int, Dict[str, np.ndarray]] = {}
         self._live_interval_ms = 33  # ~30 FPS for the live preview
         self._canny_interval_ms = 150  # ~6-7 FPS for the Canny view
         self._last_canny_timestamp: Optional[float] = None
 
-        self.status_var = tk.StringVar(value="Inaktiv. Bitte 'Start' drücken.")
+        initial_status = self._stereo_status or "Inaktiv. Bitte 'Start' drücken."
+        self.status_var = tk.StringVar(value=initial_status)
 
         self._build_layout()
         self.root.protocol("WM_DELETE_WINDOW", self.on_close)
@@ -77,20 +94,30 @@ class DualInvertApp:
 
         self._labels: Dict[int, Dict[str, ttk.Label]] = {}
 
-        panel_config = [
-            ("original", "Original"),
-            ("canny", "Canny (Invertiert)"),
-        ]
-        max_column_index = len(panel_config) - 1
+        max_column_index = 0
 
         for row, index in enumerate(self._camera_indices):
+            panel_config = [
+                ("original", "Original", "Kein Signal"),
+                ("canny", "Canny (Invertiert)", "Kein Signal"),
+            ]
+            if row == 0 and len(self._camera_indices) >= 2:
+                default_text = (
+                    "Warte auf Stereo-Daten"
+                    if self._stereo_renderer is not None
+                    else (self._stereo_status or "Stereo deaktiviert")
+                )
+                panel_config.append(("3d", "3D Ansicht", default_text))
+            max_column_index = max(max_column_index, len(panel_config) - 1)
+
             row_labels: Dict[str, ttk.Label] = {}
-            for column, (key, title_suffix) in enumerate(panel_config):
+            for column, (key, title_suffix, default_text) in enumerate(panel_config):
                 row_labels[key] = self._create_image_panel(
                     video_frame,
                     f"Kamera {row + 1} - {title_suffix}",
                     row,
                     column,
+                    default_text=default_text,
                 )
             self._labels[index] = row_labels
 
@@ -99,12 +126,42 @@ class DualInvertApp:
         for column in range(max_column_index + 1):
             video_frame.grid_columnconfigure(column, weight=1)
 
+    def _load_stereo_configuration(self) -> None:
+        self._stereo_renderer = None
+        self._stereo_calibration_size = None
+        self._stereo_pair = None
+        self._stereo_status = None
+
+        if len(self._camera_indices) < 2:
+            self._stereo_status = "Stereo-Ansicht benötigt zwei Kameras."
+            return
+
+        self._stereo_pair = (self._camera_indices[0], self._camera_indices[1])
+        calibration_path = Path("stereo_calibration.json")
+        if not calibration_path.exists():
+            self._stereo_status = (
+                f"Stereo-Ansicht deaktiviert: '{calibration_path.name}' fehlt."
+            )
+            return
+
+        try:
+            calibration = load_calibration(calibration_path)
+        except Exception as exc:  # pragma: no cover - defensive for GUI usage
+            self._stereo_status = f"Stereo-Ansicht deaktiviert: {exc}"
+            return
+
+        width, height = calibration.image_size
+        self._stereo_calibration_size = (int(width), int(height))
+        matcher = create_default_matcher()
+        self._stereo_renderer = StereoReconstructor(calibration, matcher=matcher)
+
     def _create_image_panel(
         self,
         parent: ttk.Frame,
         title: str,
         row: int,
         column: int,
+        default_text: str = "Kein Signal",
     ) -> ttk.Label:
         panel = ttk.Frame(parent)
         panel.grid(row=row, column=column, padx=5, pady=5, sticky="nsew")
@@ -112,7 +169,7 @@ class DualInvertApp:
         label_title = ttk.Label(panel, text=title, anchor="center")
         label_title.pack(fill=tk.X)
 
-        image_label = ttk.Label(panel, text="Kein Signal", anchor="center")
+        image_label = ttk.Label(panel, text=default_text, anchor="center")
         image_label.pack(fill=tk.BOTH, expand=True)
 
         return image_label
@@ -224,12 +281,60 @@ class DualInvertApp:
                     (index, "canny"),
                 )
 
+            if (
+                self._stereo_renderer is not None
+                and self._stereo_pair is not None
+                and update_canny
+            ):
+                left_index, right_index = self._stereo_pair
+                left_frame = frames.get(left_index)
+                right_frame = frames.get(right_index)
+                left_canny = canny_views.get(left_index)
+                right_canny = canny_views.get(right_index)
+
+                if (
+                    left_frame is not None
+                    and right_frame is not None
+                    and left_canny is not None
+                    and right_canny is not None
+                    and "3d" in self._labels.get(left_index, {})
+                ):
+                    try:
+                        result = self._stereo_renderer.compute(
+                            left_frame,
+                            right_frame,
+                            masks=(left_canny, right_canny),
+                        )
+                    except Exception as exc:  # pragma: no cover - runtime safety
+                        self.status_var.set(f"Stereo-Fehler: {exc}")
+                        self._clear_stereo_view(left_index)
+                    else:
+                        depth_view = result.depth_colormap
+                        self._last_frames[left_index]["3d"] = depth_view.copy()
+                        self._update_image(
+                            self._labels[left_index]["3d"],
+                            depth_view,
+                            (left_index, "3d"),
+                        )
+                elif self._stereo_pair[0] in self._labels:
+                    self._clear_stereo_view(self._stereo_pair[0])
+
             for index in missing_indices:
                 if index in self._labels:
                     for key in ("original", "canny"):
                         if key in self._labels[index]:
                             self._clear_image(self._labels[index][key], (index, key))
                 self._last_frames.pop(index, None)
+
+            if self._stereo_pair is not None:
+                left_index, right_index = self._stereo_pair
+                if (
+                    left_index in missing_indices
+                    or right_index in missing_indices
+                    or left_index not in frames
+                    or right_index not in frames
+                ):
+                    self._clear_stereo_view(left_index)
 
         self.root.after(self._live_interval_ms, self._update_loop)
 
@@ -253,3 +358,17 @@ class DualInvertApp:
             self._last_frames[index].pop(view_name, None)
             if not self._last_frames[index]:
                 self._last_frames.pop(index)
+
+    def _clear_stereo_view(self, left_index: int) -> None:
+        if left_index not in self._labels:
+            return
+        label = self._labels[left_index].get("3d")
+        if label is None:
+            return
+        self._clear_image(label, (left_index, "3d"))
+        message = (
+            "Warte auf Stereo-Daten"
+            if self._stereo_renderer is not None
+            else (self._stereo_status or "Stereo deaktiviert")
+        )
+        label.configure(text=message)

--- a/gui.py
+++ b/gui.py
@@ -12,11 +12,11 @@ import tkinter as tk
 from tkinter import ttk
 
 from camera_capture import MultiCameraCapture
-from filters import canny_edges, denoise, invert
+from filters import canny_from_inverted, invert_grayscale
 
 
 class DualInvertApp:
-    """GUI application showing original and inverted views for cameras."""
+    """GUI application showing original and processed views for cameras."""
 
     def __init__(
         self,
@@ -75,9 +75,8 @@ class DualInvertApp:
 
         panel_config = [
             ("original", "Original"),
-            ("denoised", "Rauschreduziert"),
-            ("inverted", "Invertiert"),
-            ("canny", "Canny"),
+            ("inverted", "Invertiert (Graustufen)"),
+            ("canny", "Canny (Invertiert)"),
         ]
         max_column_index = len(panel_config) - 1
 
@@ -172,7 +171,6 @@ class DualInvertApp:
     def _update_loop(self) -> None:
         if self._capture.is_running():
             frames: Dict[int, np.ndarray] = {}
-            denoised_views: Dict[int, np.ndarray] = {}
             inverted_views: Dict[int, np.ndarray] = {}
             canny_views: Dict[int, np.ndarray] = {}
             missing_indices: List[int] = []
@@ -184,18 +182,15 @@ class DualInvertApp:
                     continue
 
                 original_frame = frame.copy()
-                denoised = denoise(original_frame)
-                inverted = invert(denoised)
-                canny_view = canny_edges(denoised)
+                inverted = invert_grayscale(original_frame)
+                canny_view = canny_from_inverted(inverted)
 
                 frames[index] = original_frame
-                denoised_views[index] = denoised
                 inverted_views[index] = inverted
                 canny_views[index] = canny_view
 
                 self._last_frames.setdefault(index, {})
                 self._last_frames[index]["original"] = original_frame.copy()
-                self._last_frames[index]["denoised"] = denoised.copy()
                 self._last_frames[index]["inverted"] = inverted.copy()
                 self._last_frames[index]["canny"] = canny_view.copy()
 
@@ -204,11 +199,6 @@ class DualInvertApp:
                     self._labels[index]["original"],
                     original_frame,
                     (index, "original"),
-                )
-                self._update_image(
-                    self._labels[index]["denoised"],
-                    denoised_views[index],
-                    (index, "denoised"),
                 )
                 self._update_image(
                     self._labels[index]["inverted"],
@@ -223,12 +213,12 @@ class DualInvertApp:
 
             for index in missing_indices:
                 if index in self._labels:
-                    for key in ("original", "denoised", "inverted", "canny"):
+                    for key in ("original", "inverted", "canny"):
                         if key in self._labels[index]:
                             self._clear_image(self._labels[index][key], (index, key))
                 self._last_frames.pop(index, None)
 
-        self.root.after(33, self._update_loop)
+        self.root.after(100, self._update_loop)
 
     def _update_image(self, label: ttk.Label, frame, key: Tuple[int, str]) -> None:
         rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)

--- a/gui.py
+++ b/gui.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import base64
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
+import time
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -30,6 +31,9 @@ class DualInvertApp:
         self._capture = MultiCameraCapture(self._camera_indices)
         self._photo_images: Dict[Tuple[int, str], tk.PhotoImage] = {}
         self._last_frames: Dict[int, Dict[str, np.ndarray]] = {}
+        self._live_interval_ms = 33  # ~30 FPS for the live preview
+        self._canny_interval_ms = 150  # ~6-7 FPS for the Canny view
+        self._last_canny_timestamp: Optional[float] = None
 
         self.status_var = tk.StringVar(value="Inaktiv. Bitte 'Start' drücken.")
 
@@ -75,7 +79,6 @@ class DualInvertApp:
 
         panel_config = [
             ("original", "Original"),
-            ("inverted", "Invertiert (Graustufen)"),
             ("canny", "Canny (Invertiert)"),
         ]
         max_column_index = len(panel_config) - 1
@@ -124,10 +127,12 @@ class DualInvertApp:
             return
 
         self.status_var.set("Live-Ansicht aktiv.")
+        self._last_canny_timestamp = None
 
     def stop_cameras(self) -> None:
         self._capture.stop()
         self.status_var.set("Aufnahme gestoppt.")
+        self._last_canny_timestamp = None
 
     def on_close(self) -> None:
         self.stop_cameras()
@@ -171,9 +176,17 @@ class DualInvertApp:
     def _update_loop(self) -> None:
         if self._capture.is_running():
             frames: Dict[int, np.ndarray] = {}
-            inverted_views: Dict[int, np.ndarray] = {}
             canny_views: Dict[int, np.ndarray] = {}
+            canny_refresh: List[int] = []
             missing_indices: List[int] = []
+
+            now = time.perf_counter()
+            update_canny = (
+                self._last_canny_timestamp is None
+                or (now - self._last_canny_timestamp) * 1000 >= self._canny_interval_ms
+            )
+            if update_canny:
+                self._last_canny_timestamp = now
 
             for index in self._camera_indices:
                 frame = self._capture.read(index)
@@ -182,17 +195,21 @@ class DualInvertApp:
                     continue
 
                 original_frame = frame.copy()
-                inverted = invert_grayscale(original_frame)
-                canny_view = canny_from_inverted(inverted)
-
                 frames[index] = original_frame
-                inverted_views[index] = inverted
-                canny_views[index] = canny_view
 
                 self._last_frames.setdefault(index, {})
                 self._last_frames[index]["original"] = original_frame.copy()
-                self._last_frames[index]["inverted"] = inverted.copy()
-                self._last_frames[index]["canny"] = canny_view.copy()
+
+                stored_canny = self._last_frames[index].get("canny")
+                refresh_canny = update_canny or stored_canny is None
+                if refresh_canny:
+                    inverted = invert_grayscale(original_frame)
+                    stored_canny = canny_from_inverted(inverted)
+                    self._last_frames[index]["canny"] = stored_canny.copy()
+                if stored_canny is not None:
+                    canny_views[index] = stored_canny
+                    if refresh_canny:
+                        canny_refresh.append(index)
 
             for index, original_frame in frames.items():
                 self._update_image(
@@ -200,11 +217,7 @@ class DualInvertApp:
                     original_frame,
                     (index, "original"),
                 )
-                self._update_image(
-                    self._labels[index]["inverted"],
-                    inverted_views[index],
-                    (index, "inverted"),
-                )
+            for index in canny_refresh:
                 self._update_image(
                     self._labels[index]["canny"],
                     canny_views[index],
@@ -213,12 +226,12 @@ class DualInvertApp:
 
             for index in missing_indices:
                 if index in self._labels:
-                    for key in ("original", "inverted", "canny"):
+                    for key in ("original", "canny"):
                         if key in self._labels[index]:
                             self._clear_image(self._labels[index][key], (index, key))
                 self._last_frames.pop(index, None)
 
-        self.root.after(100, self._update_loop)
+        self.root.after(self._live_interval_ms, self._update_loop)
 
     def _update_image(self, label: ttk.Label, frame, key: Tuple[int, str]) -> None:
         rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)

--- a/gui.py
+++ b/gui.py
@@ -169,43 +169,74 @@ class DualInvertApp:
 
     def _update_loop(self) -> None:
         if self._capture.is_running():
+            frames: Dict[int, np.ndarray] = {}
+            inverted_views: Dict[int, np.ndarray] = {}
+            missing_indices: List[int] = []
+
             for index in self._camera_indices:
                 frame = self._capture.read(index)
-                if frame is not None:
-                    original_frame = frame.copy()
-                    inverted = invert(frame)
+                if frame is None:
+                    missing_indices.append(index)
+                    continue
 
-                    self._last_frames.setdefault(index, {})
-                    self._last_frames[index]["original"] = original_frame
-                    self._last_frames[index]["inverted"] = inverted.copy()
+                original_frame = frame.copy()
+                inverted = invert(frame)
 
-                    if index == 0 and "circles" in self._labels[index]:
-                        circle_view = detect_small_circles(frame)
-                        self._last_frames[index]["circles"] = circle_view.copy()
-                        self._update_image(
-                            self._labels[index]["circles"],
-                            circle_view,
-                            (index, "circles"),
-                        )
+                frames[index] = original_frame
+                inverted_views[index] = inverted
 
-                    self._update_image(
-                        self._labels[index]["original"],
-                        original_frame,
-                        (index, "original"),
-                    )
-                    self._update_image(
-                        self._labels[index]["inverted"],
-                        inverted,
-                        (index, "inverted"),
-                    )
-                else:
+                self._last_frames.setdefault(index, {})
+                self._last_frames[index]["original"] = original_frame.copy()
+                self._last_frames[index]["inverted"] = inverted.copy()
+
+            for index, original_frame in frames.items():
+                self._update_image(
+                    self._labels[index]["original"],
+                    original_frame,
+                    (index, "original"),
+                )
+                self._update_image(
+                    self._labels[index]["inverted"],
+                    inverted_views[index],
+                    (index, "inverted"),
+                )
+
+            for index in missing_indices:
+                if index in self._labels:
                     self._clear_image(self._labels[index]["original"], (index, "original"))
                     self._clear_image(self._labels[index]["inverted"], (index, "inverted"))
                     if "circles" in self._labels[index]:
                         self._clear_image(
                             self._labels[index]["circles"], (index, "circles")
                         )
-                    self._last_frames.pop(index, None)
+                self._last_frames.pop(index, None)
+
+            if 0 in self._labels and "circles" in self._labels[0]:
+                if 0 in frames:
+                    secondary_inverted = None
+                    for other_index in self._camera_indices:
+                        if other_index == 0:
+                            continue
+                        if other_index in inverted_views:
+                            secondary_inverted = inverted_views[other_index]
+                            break
+
+                    circle_view = detect_small_circles(
+                        frames[0],
+                        inverted_views.get(0),
+                        secondary_inverted,
+                    )
+                    self._last_frames.setdefault(0, {})
+                    self._last_frames[0]["circles"] = circle_view.copy()
+                    self._update_image(
+                        self._labels[0]["circles"],
+                        circle_view,
+                        (0, "circles"),
+                    )
+                else:
+                    self._clear_image(self._labels[0]["circles"], (0, "circles"))
+                    if 0 in self._last_frames:
+                        self._last_frames[0].pop("circles", None)
 
         self.root.after(33, self._update_loop)
 

--- a/gui.py
+++ b/gui.py
@@ -12,7 +12,7 @@ import tkinter as tk
 from tkinter import ttk
 
 from camera_capture import MultiCameraCapture
-from filters import detect_small_circles, invert
+from filters import detect_small_circles, invert, merge_inverted_canny
 
 
 class DualInvertApp:
@@ -73,7 +73,7 @@ class DualInvertApp:
 
         self._labels: Dict[int, Dict[str, ttk.Label]] = {}
 
-        max_column_index = 2 if 0 in self._camera_indices else 1
+        max_column_index = 3 if 0 in self._camera_indices else 1
 
         for row, index in enumerate(self._camera_indices):
             row_labels: Dict[str, ttk.Label] = {
@@ -85,8 +85,11 @@ class DualInvertApp:
                 ),
             }
             if index == 0:
+                row_labels["canny_merge"] = self._create_image_panel(
+                    video_frame, "Kamera 1 - Canny Merge", row, 2
+                )
                 row_labels["circles"] = self._create_image_panel(
-                    video_frame, "Kamera 1 - Kreiserkennung", row, 2
+                    video_frame, "Kamera 1 - Kreiserkennung", row, 3
                 )
             self._labels[index] = row_labels
 
@@ -205,13 +208,17 @@ class DualInvertApp:
                 if index in self._labels:
                     self._clear_image(self._labels[index]["original"], (index, "original"))
                     self._clear_image(self._labels[index]["inverted"], (index, "inverted"))
+                    if "canny_merge" in self._labels[index]:
+                        self._clear_image(
+                            self._labels[index]["canny_merge"], (index, "canny_merge")
+                        )
                     if "circles" in self._labels[index]:
                         self._clear_image(
                             self._labels[index]["circles"], (index, "circles")
                         )
                 self._last_frames.pop(index, None)
 
-            if 0 in self._labels and "circles" in self._labels[0]:
+            if 0 in self._labels:
                 if 0 in frames:
                     secondary_inverted = None
                     for other_index in self._camera_indices:
@@ -221,22 +228,52 @@ class DualInvertApp:
                             secondary_inverted = inverted_views[other_index]
                             break
 
-                    circle_view = detect_small_circles(
-                        frames[0],
-                        inverted_views.get(0),
-                        secondary_inverted,
-                    )
-                    self._last_frames.setdefault(0, {})
-                    self._last_frames[0]["circles"] = circle_view.copy()
-                    self._update_image(
-                        self._labels[0]["circles"],
-                        circle_view,
-                        (0, "circles"),
-                    )
+                    primary_inverted = inverted_views.get(0)
+
+                    if "canny_merge" in self._labels[0] and primary_inverted is not None:
+                        canny_view = merge_inverted_canny(
+                            primary_inverted, secondary_inverted
+                        )
+                        if canny_view is None:
+                            canny_view = np.zeros_like(frames[0])
+                        self._last_frames.setdefault(0, {})
+                        self._last_frames[0]["canny_merge"] = canny_view.copy()
+                        self._update_image(
+                            self._labels[0]["canny_merge"],
+                            canny_view,
+                            (0, "canny_merge"),
+                        )
+                    elif "canny_merge" in self._labels[0]:
+                        self._clear_image(
+                            self._labels[0]["canny_merge"], (0, "canny_merge")
+                        )
+                        if 0 in self._last_frames:
+                            self._last_frames[0].pop("canny_merge", None)
+
+                    if "circles" in self._labels[0]:
+                        circle_view = detect_small_circles(
+                            frames[0],
+                            primary_inverted,
+                            secondary_inverted,
+                        )
+                        self._last_frames.setdefault(0, {})
+                        self._last_frames[0]["circles"] = circle_view.copy()
+                        self._update_image(
+                            self._labels[0]["circles"],
+                            circle_view,
+                            (0, "circles"),
+                        )
                 else:
-                    self._clear_image(self._labels[0]["circles"], (0, "circles"))
-                    if 0 in self._last_frames:
-                        self._last_frames[0].pop("circles", None)
+                    if "canny_merge" in self._labels[0]:
+                        self._clear_image(
+                            self._labels[0]["canny_merge"], (0, "canny_merge")
+                        )
+                        if 0 in self._last_frames:
+                            self._last_frames[0].pop("canny_merge", None)
+                    if "circles" in self._labels[0]:
+                        self._clear_image(self._labels[0]["circles"], (0, "circles"))
+                        if 0 in self._last_frames:
+                            self._last_frames[0].pop("circles", None)
 
         self.root.after(33, self._update_loop)
 

--- a/gui.py
+++ b/gui.py
@@ -12,7 +12,7 @@ import tkinter as tk
 from tkinter import ttk
 
 from camera_capture import MultiCameraCapture
-from filters import detect_small_circles, invert, merge_inverted_canny
+from filters import canny_edges, denoise, invert
 
 
 class DualInvertApp:
@@ -73,23 +73,22 @@ class DualInvertApp:
 
         self._labels: Dict[int, Dict[str, ttk.Label]] = {}
 
-        max_column_index = 3 if 0 in self._camera_indices else 1
+        panel_config = [
+            ("original", "Original"),
+            ("denoised", "Rauschreduziert"),
+            ("inverted", "Invertiert"),
+            ("canny", "Canny"),
+        ]
+        max_column_index = len(panel_config) - 1
 
         for row, index in enumerate(self._camera_indices):
-            row_labels: Dict[str, ttk.Label] = {
-                "original": self._create_image_panel(
-                    video_frame, f"Kamera {row + 1} - Original", row, 0
-                ),
-                "inverted": self._create_image_panel(
-                    video_frame, f"Kamera {row + 1} - Invertiert", row, 1
-                ),
-            }
-            if index == 0:
-                row_labels["canny_merge"] = self._create_image_panel(
-                    video_frame, "Kamera 1 - Canny Merge", row, 2
-                )
-                row_labels["circles"] = self._create_image_panel(
-                    video_frame, "Kamera 1 - Kreiserkennung", row, 3
+            row_labels: Dict[str, ttk.Label] = {}
+            for column, (key, title_suffix) in enumerate(panel_config):
+                row_labels[key] = self._create_image_panel(
+                    video_frame,
+                    f"Kamera {row + 1} - {title_suffix}",
+                    row,
+                    column,
                 )
             self._labels[index] = row_labels
 
@@ -173,7 +172,9 @@ class DualInvertApp:
     def _update_loop(self) -> None:
         if self._capture.is_running():
             frames: Dict[int, np.ndarray] = {}
+            denoised_views: Dict[int, np.ndarray] = {}
             inverted_views: Dict[int, np.ndarray] = {}
+            canny_views: Dict[int, np.ndarray] = {}
             missing_indices: List[int] = []
 
             for index in self._camera_indices:
@@ -183,14 +184,20 @@ class DualInvertApp:
                     continue
 
                 original_frame = frame.copy()
-                inverted = invert(frame)
+                denoised = denoise(original_frame)
+                inverted = invert(denoised)
+                canny_view = canny_edges(denoised)
 
                 frames[index] = original_frame
+                denoised_views[index] = denoised
                 inverted_views[index] = inverted
+                canny_views[index] = canny_view
 
                 self._last_frames.setdefault(index, {})
                 self._last_frames[index]["original"] = original_frame.copy()
+                self._last_frames[index]["denoised"] = denoised.copy()
                 self._last_frames[index]["inverted"] = inverted.copy()
+                self._last_frames[index]["canny"] = canny_view.copy()
 
             for index, original_frame in frames.items():
                 self._update_image(
@@ -199,81 +206,27 @@ class DualInvertApp:
                     (index, "original"),
                 )
                 self._update_image(
+                    self._labels[index]["denoised"],
+                    denoised_views[index],
+                    (index, "denoised"),
+                )
+                self._update_image(
                     self._labels[index]["inverted"],
                     inverted_views[index],
                     (index, "inverted"),
                 )
+                self._update_image(
+                    self._labels[index]["canny"],
+                    canny_views[index],
+                    (index, "canny"),
+                )
 
             for index in missing_indices:
                 if index in self._labels:
-                    self._clear_image(self._labels[index]["original"], (index, "original"))
-                    self._clear_image(self._labels[index]["inverted"], (index, "inverted"))
-                    if "canny_merge" in self._labels[index]:
-                        self._clear_image(
-                            self._labels[index]["canny_merge"], (index, "canny_merge")
-                        )
-                    if "circles" in self._labels[index]:
-                        self._clear_image(
-                            self._labels[index]["circles"], (index, "circles")
-                        )
+                    for key in ("original", "denoised", "inverted", "canny"):
+                        if key in self._labels[index]:
+                            self._clear_image(self._labels[index][key], (index, key))
                 self._last_frames.pop(index, None)
-
-            if 0 in self._labels:
-                if 0 in frames:
-                    secondary_inverted = None
-                    for other_index in self._camera_indices:
-                        if other_index == 0:
-                            continue
-                        if other_index in inverted_views:
-                            secondary_inverted = inverted_views[other_index]
-                            break
-
-                    primary_inverted = inverted_views.get(0)
-
-                    if "canny_merge" in self._labels[0] and primary_inverted is not None:
-                        canny_view = merge_inverted_canny(
-                            primary_inverted, secondary_inverted
-                        )
-                        if canny_view is None:
-                            canny_view = np.zeros_like(frames[0])
-                        self._last_frames.setdefault(0, {})
-                        self._last_frames[0]["canny_merge"] = canny_view.copy()
-                        self._update_image(
-                            self._labels[0]["canny_merge"],
-                            canny_view,
-                            (0, "canny_merge"),
-                        )
-                    elif "canny_merge" in self._labels[0]:
-                        self._clear_image(
-                            self._labels[0]["canny_merge"], (0, "canny_merge")
-                        )
-                        if 0 in self._last_frames:
-                            self._last_frames[0].pop("canny_merge", None)
-
-                    if "circles" in self._labels[0]:
-                        circle_view = detect_small_circles(
-                            frames[0],
-                            primary_inverted,
-                            secondary_inverted,
-                        )
-                        self._last_frames.setdefault(0, {})
-                        self._last_frames[0]["circles"] = circle_view.copy()
-                        self._update_image(
-                            self._labels[0]["circles"],
-                            circle_view,
-                            (0, "circles"),
-                        )
-                else:
-                    if "canny_merge" in self._labels[0]:
-                        self._clear_image(
-                            self._labels[0]["canny_merge"], (0, "canny_merge")
-                        )
-                        if 0 in self._last_frames:
-                            self._last_frames[0].pop("canny_merge", None)
-                    if "circles" in self._labels[0]:
-                        self._clear_image(self._labels[0]["circles"], (0, "circles"))
-                        if 0 in self._last_frames:
-                            self._last_frames[0].pop("circles", None)
 
         self.root.after(33, self._update_loop)
 

--- a/gui.py
+++ b/gui.py
@@ -12,7 +12,7 @@ import tkinter as tk
 from tkinter import ttk
 
 from camera_capture import MultiCameraCapture
-from filters import invert
+from filters import detect_small_circles, invert
 
 
 class DualInvertApp:
@@ -73,8 +73,10 @@ class DualInvertApp:
 
         self._labels: Dict[int, Dict[str, ttk.Label]] = {}
 
+        max_column_index = 2 if 0 in self._camera_indices else 1
+
         for row, index in enumerate(self._camera_indices):
-            self._labels[index] = {
+            row_labels: Dict[str, ttk.Label] = {
                 "original": self._create_image_panel(
                     video_frame, f"Kamera {row + 1} - Original", row, 0
                 ),
@@ -82,10 +84,15 @@ class DualInvertApp:
                     video_frame, f"Kamera {row + 1} - Invertiert", row, 1
                 ),
             }
+            if index == 0:
+                row_labels["circles"] = self._create_image_panel(
+                    video_frame, "Kamera 1 - Kreiserkennung", row, 2
+                )
+            self._labels[index] = row_labels
 
         for row in range(len(self._camera_indices)):
             video_frame.grid_rowconfigure(row, weight=1)
-        for column in range(2):
+        for column in range(max_column_index + 1):
             video_frame.grid_columnconfigure(column, weight=1)
 
     def _create_image_panel(
@@ -172,6 +179,15 @@ class DualInvertApp:
                     self._last_frames[index]["original"] = original_frame
                     self._last_frames[index]["inverted"] = inverted.copy()
 
+                    if index == 0 and "circles" in self._labels[index]:
+                        circle_view = detect_small_circles(frame)
+                        self._last_frames[index]["circles"] = circle_view.copy()
+                        self._update_image(
+                            self._labels[index]["circles"],
+                            circle_view,
+                            (index, "circles"),
+                        )
+
                     self._update_image(
                         self._labels[index]["original"],
                         original_frame,
@@ -185,6 +201,10 @@ class DualInvertApp:
                 else:
                     self._clear_image(self._labels[index]["original"], (index, "original"))
                     self._clear_image(self._labels[index]["inverted"], (index, "inverted"))
+                    if "circles" in self._labels[index]:
+                        self._clear_image(
+                            self._labels[index]["circles"], (index, "circles")
+                        )
                     self._last_frames.pop(index, None)
 
         self.root.after(33, self._update_loop)

--- a/stereo_reconstruction.py
+++ b/stereo_reconstruction.py
@@ -1,0 +1,401 @@
+"""Utilities for calibrating stereo camera rigs and reconstructing 3D views."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+
+@dataclass
+class StereoCalibrationData:
+    """Container with the intrinsic and extrinsic stereo parameters."""
+
+    image_size: Tuple[int, int]
+    camera_matrix_left: np.ndarray
+    dist_coeffs_left: np.ndarray
+    camera_matrix_right: np.ndarray
+    dist_coeffs_right: np.ndarray
+    rotation_matrix: np.ndarray
+    translation_vector: np.ndarray
+    rectification_matrix_left: np.ndarray
+    rectification_matrix_right: np.ndarray
+    projection_matrix_left: np.ndarray
+    projection_matrix_right: np.ndarray
+    disparity_to_depth_map: np.ndarray
+    reprojection_error: float
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the calibration to a plain dictionary."""
+
+        return {
+            "image_size": list(self.image_size),
+            "camera_matrix_left": self.camera_matrix_left.tolist(),
+            "dist_coeffs_left": self.dist_coeffs_left.tolist(),
+            "camera_matrix_right": self.camera_matrix_right.tolist(),
+            "dist_coeffs_right": self.dist_coeffs_right.tolist(),
+            "rotation_matrix": self.rotation_matrix.tolist(),
+            "translation_vector": self.translation_vector.tolist(),
+            "rectification_matrix_left": self.rectification_matrix_left.tolist(),
+            "rectification_matrix_right": self.rectification_matrix_right.tolist(),
+            "projection_matrix_left": self.projection_matrix_left.tolist(),
+            "projection_matrix_right": self.projection_matrix_right.tolist(),
+            "disparity_to_depth_map": self.disparity_to_depth_map.tolist(),
+            "reprojection_error": float(self.reprojection_error),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "StereoCalibrationData":
+        """Re-create a :class:`StereoCalibrationData` from a JSON dictionary."""
+
+        def _array(key: str) -> np.ndarray:
+            value = data.get(key)
+            if value is None:
+                raise KeyError(f"Missing calibration field '{key}'.")
+            return np.array(value, dtype=np.float64)
+
+        image_size = data.get("image_size")
+        if image_size is None:
+            raise KeyError("Missing calibration field 'image_size'.")
+        width, height = (int(image_size[0]), int(image_size[1]))
+
+        return cls(
+            image_size=(width, height),
+            camera_matrix_left=_array("camera_matrix_left"),
+            dist_coeffs_left=_array("dist_coeffs_left"),
+            camera_matrix_right=_array("camera_matrix_right"),
+            dist_coeffs_right=_array("dist_coeffs_right"),
+            rotation_matrix=_array("rotation_matrix"),
+            translation_vector=_array("translation_vector"),
+            rectification_matrix_left=_array("rectification_matrix_left"),
+            rectification_matrix_right=_array("rectification_matrix_right"),
+            projection_matrix_left=_array("projection_matrix_left"),
+            projection_matrix_right=_array("projection_matrix_right"),
+            disparity_to_depth_map=_array("disparity_to_depth_map"),
+            reprojection_error=float(data.get("reprojection_error", 0.0)),
+        )
+
+
+def _prepare_object_points(
+    pattern_size: Tuple[int, int],
+    square_size: float,
+) -> np.ndarray:
+    cols, rows = pattern_size
+    grid = np.mgrid[0:cols, 0:rows].T.reshape(-1, 2)
+    object_points = np.zeros((rows * cols, 3), np.float32)
+    object_points[:, :2] = grid * square_size
+    return object_points
+
+
+def _find_corners(
+    image: np.ndarray,
+    pattern_size: Tuple[int, int],
+    criteria: Tuple[int, int, float],
+) -> Optional[np.ndarray]:
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    found, corners = cv2.findChessboardCorners(gray, pattern_size)
+    if not found:
+        return None
+    refined = cv2.cornerSubPix(
+        gray,
+        corners,
+        winSize=(11, 11),
+        zeroZone=(-1, -1),
+        criteria=criteria,
+    )
+    return refined
+
+
+def compute_stereo_calibration(
+    image_pairs: Iterable[Tuple[np.ndarray, np.ndarray]],
+    pattern_size: Tuple[int, int] = (6, 6),
+    square_size: float = 1.0,
+) -> StereoCalibrationData:
+    """Compute stereo calibration parameters from chessboard image pairs."""
+
+    criteria = (
+        cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER,
+        100,
+        1e-5,
+    )
+
+    object_points: List[np.ndarray] = []
+    image_points_left: List[np.ndarray] = []
+    image_points_right: List[np.ndarray] = []
+
+    image_size: Optional[Tuple[int, int]] = None
+
+    base_object_points = _prepare_object_points(pattern_size, square_size)
+
+    for left, right in image_pairs:
+        if left is None or right is None:
+            continue
+        if left.shape[:2] != right.shape[:2]:
+            raise ValueError("Stereo pair images must share the same resolution.")
+
+        if image_size is None:
+            image_size = (left.shape[1], left.shape[0])
+
+        corners_left = _find_corners(left, pattern_size, criteria)
+        corners_right = _find_corners(right, pattern_size, criteria)
+
+        if corners_left is None or corners_right is None:
+            continue
+
+        object_points.append(base_object_points.copy())
+        image_points_left.append(corners_left)
+        image_points_right.append(corners_right)
+
+    if not object_points:
+        raise ValueError("Keine gültigen Schachbrettpaare für die Kalibrierung gefunden.")
+
+    if image_size is None:
+        raise ValueError("Die Bildgröße der Kalibrierung konnte nicht bestimmt werden.")
+
+    rms, camera_matrix_left, dist_coeffs_left, camera_matrix_right, dist_coeffs_right, rotation_matrix, translation_vector, _, _ = (
+        cv2.stereoCalibrate(
+            object_points,
+            image_points_left,
+            image_points_right,
+            None,
+            None,
+            None,
+            None,
+            image_size,
+            criteria=criteria,
+            flags=0,
+        )
+    )
+
+    (
+        rectification_matrix_left,
+        rectification_matrix_right,
+        projection_matrix_left,
+        projection_matrix_right,
+        disparity_to_depth_map,
+        _,
+        _,
+    ) = cv2.stereoRectify(
+        camera_matrix_left,
+        dist_coeffs_left,
+        camera_matrix_right,
+        dist_coeffs_right,
+        image_size,
+        rotation_matrix,
+        translation_vector,
+        flags=cv2.CALIB_ZERO_DISPARITY,
+        alpha=0,
+    )
+
+    return StereoCalibrationData(
+        image_size=image_size,
+        camera_matrix_left=camera_matrix_left,
+        dist_coeffs_left=dist_coeffs_left,
+        camera_matrix_right=camera_matrix_right,
+        dist_coeffs_right=dist_coeffs_right,
+        rotation_matrix=rotation_matrix,
+        translation_vector=translation_vector,
+        rectification_matrix_left=rectification_matrix_left,
+        rectification_matrix_right=rectification_matrix_right,
+        projection_matrix_left=projection_matrix_left,
+        projection_matrix_right=projection_matrix_right,
+        disparity_to_depth_map=disparity_to_depth_map,
+        reprojection_error=rms,
+    )
+
+
+def save_calibration(path: Path, calibration: StereoCalibrationData) -> None:
+    """Persist calibration data as JSON."""
+
+    path = Path(path)
+    path.write_text(json.dumps(calibration.to_dict(), indent=2), encoding="utf-8")
+
+
+def load_calibration(path: Path) -> StereoCalibrationData:
+    """Load calibration parameters from *path*."""
+
+    path = Path(path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return StereoCalibrationData.from_dict(data)
+
+
+def create_default_matcher(
+    min_disparity: int = 0,
+    num_disparities: int = 128,
+    block_size: int = 5,
+) -> cv2.StereoMatcher:
+    """Create a default StereoSGBM matcher suitable for medium resolutions."""
+
+    num_disparities = max(16, int(np.ceil(num_disparities / 16)) * 16)
+    matcher = cv2.StereoSGBM_create(
+        minDisparity=min_disparity,
+        numDisparities=num_disparities,
+        blockSize=block_size,
+        P1=8 * 3 * block_size ** 2,
+        P2=32 * 3 * block_size ** 2,
+        mode=cv2.STEREO_SGBM_MODE_SGBM_3WAY,
+    )
+    matcher.setUniquenessRatio(10)
+    matcher.setSpeckleWindowSize(100)
+    matcher.setSpeckleRange(32)
+    matcher.setDisp12MaxDiff(1)
+    matcher.setPreFilterCap(63)
+    matcher.setP1(8 * 3 * block_size ** 2)
+    matcher.setP2(32 * 3 * block_size ** 2)
+    return matcher
+
+
+@dataclass
+class StereoReconstructionResult:
+    """Result of a single stereo reconstruction step."""
+
+    rectified_left: np.ndarray
+    rectified_right: np.ndarray
+    disparity: np.ndarray
+    depth_colormap: np.ndarray
+    point_cloud: np.ndarray
+    mask: np.ndarray
+
+    def filtered_points(self) -> np.ndarray:
+        """Return only valid 3D points."""
+
+        valid = self.mask.reshape(-1)
+        points = self.point_cloud.reshape(-1, 3)
+        return points[valid]
+
+
+class StereoReconstructor:
+    """Convenience wrapper that caches rectification maps and computes depth."""
+
+    def __init__(
+        self,
+        calibration: StereoCalibrationData,
+        matcher: Optional[cv2.StereoMatcher] = None,
+    ) -> None:
+        self.calibration = calibration
+        self.matcher = matcher or create_default_matcher()
+        self._map_cache: Dict[Tuple[int, int], Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
+
+    def _get_maps(
+        self, image_size: Tuple[int, int]
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        if image_size not in self._map_cache:
+            map_left = cv2.initUndistortRectifyMap(
+                self.calibration.camera_matrix_left,
+                self.calibration.dist_coeffs_left,
+                self.calibration.rectification_matrix_left,
+                self.calibration.projection_matrix_left,
+                image_size,
+                cv2.CV_32FC1,
+            )
+            map_right = cv2.initUndistortRectifyMap(
+                self.calibration.camera_matrix_right,
+                self.calibration.dist_coeffs_right,
+                self.calibration.rectification_matrix_right,
+                self.calibration.projection_matrix_right,
+                image_size,
+                cv2.CV_32FC1,
+            )
+            self._map_cache[image_size] = (*map_left, *map_right)
+        return self._map_cache[image_size]
+
+    def _rectify_pair(
+        self,
+        left: np.ndarray,
+        right: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray, Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
+        if left.shape[:2] != right.shape[:2]:
+            raise ValueError("Linkes und rechtes Bild müssen gleich groß sein.")
+
+        height, width = left.shape[:2]
+        if (width, height) != self.calibration.image_size:
+            raise ValueError(
+                "Die Auflösung der Live-Bilder entspricht nicht der Kalibrierung."
+            )
+
+        map1_left, map2_left, map1_right, map2_right = self._get_maps((width, height))
+        rect_left = cv2.remap(left, map1_left, map2_left, cv2.INTER_LINEAR)
+        rect_right = cv2.remap(right, map1_right, map2_right, cv2.INTER_LINEAR)
+        return rect_left, rect_right, (map1_left, map2_left, map1_right, map2_right)
+
+    @staticmethod
+    def _remap_mask(mask: np.ndarray, map1: np.ndarray, map2: np.ndarray) -> np.ndarray:
+        if mask.ndim == 3:
+            mask = cv2.cvtColor(mask, cv2.COLOR_BGR2GRAY)
+        rect_mask = cv2.remap(mask, map1, map2, cv2.INTER_NEAREST)
+        return rect_mask
+
+    def compute(
+        self,
+        left: np.ndarray,
+        right: np.ndarray,
+        masks: Optional[Tuple[np.ndarray, np.ndarray]] = None,
+    ) -> StereoReconstructionResult:
+        """Compute a depth map and point cloud from *left* and *right* frames."""
+
+        rect_left, rect_right, maps = self._rectify_pair(left, right)
+        map1_left, map2_left, map1_right, map2_right = maps
+
+        gray_left = cv2.cvtColor(rect_left, cv2.COLOR_BGR2GRAY)
+        gray_right = cv2.cvtColor(rect_right, cv2.COLOR_BGR2GRAY)
+
+        disparity_raw = self.matcher.compute(gray_left, gray_right).astype(np.float32)
+        disparity = disparity_raw / 16.0
+
+        mask = np.isfinite(disparity)
+        mask &= disparity > 0
+
+        if masks is not None:
+            left_mask, right_mask = masks
+            left_mask_rect = self._remap_mask(left_mask, map1_left, map2_left)
+            right_mask_rect = self._remap_mask(right_mask, map1_right, map2_right)
+            combined_mask = cv2.bitwise_or(left_mask_rect, right_mask_rect)
+            mask &= combined_mask > 0
+
+        point_cloud = cv2.reprojectImageTo3D(disparity, self.calibration.disparity_to_depth_map)
+        point_cloud = np.where(mask[..., None], point_cloud, np.nan)
+
+        depth_colormap = _colorize_disparity(disparity, mask)
+
+        return StereoReconstructionResult(
+            rectified_left=rect_left,
+            rectified_right=rect_right,
+            disparity=disparity,
+            depth_colormap=depth_colormap,
+            point_cloud=point_cloud,
+            mask=mask,
+        )
+
+
+def _colorize_disparity(disparity: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    if disparity.size == 0:
+        return np.zeros((*disparity.shape, 3), dtype=np.uint8)
+
+    valid_values = disparity[mask]
+    if valid_values.size == 0:
+        return np.zeros((*disparity.shape, 3), dtype=np.uint8)
+
+    disp_min = np.nanmin(valid_values)
+    disp_max = np.nanmax(valid_values)
+    if disp_max - disp_min < 1e-3:
+        disp_max = disp_min + 1e-3
+
+    normalized = (disparity - disp_min) / (disp_max - disp_min)
+    normalized = np.clip(normalized, 0, 1)
+    normalized_uint8 = (normalized * 255).astype(np.uint8)
+    colored = cv2.applyColorMap(normalized_uint8, cv2.COLORMAP_TURBO)
+    colored[~mask] = 0
+    return colored
+
+
+def load_reconstructor(
+    path: Path,
+    matcher: Optional[cv2.StereoMatcher] = None,
+) -> StereoReconstructor:
+    """Load calibration data from *path* and build a :class:`StereoReconstructor`."""
+
+    calibration = load_calibration(path)
+    return StereoReconstructor(calibration, matcher=matcher)


### PR DESCRIPTION
## Summary
- add a circle detection filter that extracts dominant radii and stabilises the rendering of small, repeating circles
- extend the GUI to compute the new filter for camera 0 and present the result in a dedicated panel

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cbcdc0eddc83268dfd0d29daff313c