### PR TITLE
Improve camera initialization concurrency and status feedback

### DIFF
--- a/camera_capture.py
+++ b/camera_capture.py
@@ -1,6 +1,7 @@
 """Camera capture management for multi-camera setups."""
 from __future__ import annotations
 
+import concurrent.futures
 from typing import Dict, Iterable, Optional, Tuple
 
 import cv2
@@ -31,26 +32,79 @@ class MultiCameraCapture:
         self._backend = backend
         self._captures: Dict[int, cv2.VideoCapture] = {}
 
+    def _open_single_capture(self, index: int) -> Optional[cv2.VideoCapture]:
+        """Create and initialize a single ``VideoCapture`` instance."""
+
+        capture = cv2.VideoCapture(index, self._backend)
+        capture.set(cv2.CAP_PROP_FPS, 30)
+        if not capture.isOpened():
+            capture.release()
+            return None
+        return capture
+
     def start(self) -> bool:
         """Open all configured camera indices."""
 
         if self.is_running():
             return True
 
-        opened: Dict[int, cv2.VideoCapture] = {}
-        success = True
-        for index in self._indices:
-            capture = cv2.VideoCapture(index, self._backend)
-            if not capture.isOpened():
-                capture.release()
-                success = False
-                break
-            opened[index] = capture
+        def open_sequential() -> Optional[Dict[int, cv2.VideoCapture]]:
+            sequential_opened: Dict[int, cv2.VideoCapture] = {}
+            for cam_index in self._indices:
+                capture = self._open_single_capture(cam_index)
+                if capture is None:
+                    for handle in sequential_opened.values():
+                        handle.release()
+                    return None
+                sequential_opened[cam_index] = capture
+            return sequential_opened
 
-        if not success:
-            for capture in opened.values():
-                capture.release()
-            return False
+        if len(self._indices) <= 1:
+            sequential_result = open_sequential()
+            if sequential_result is None:
+                return False
+            self._captures = sequential_result
+            return True
+
+        opened: Dict[int, cv2.VideoCapture] = {}
+        try:
+            failure_detected = False
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=len(self._indices)
+            ) as executor:
+                futures = {
+                    executor.submit(self._open_single_capture, index): index
+                    for index in self._indices
+                }
+
+                for future in concurrent.futures.as_completed(futures):
+                    index = futures[future]
+                    try:
+                        capture = future.result()
+                    except Exception:
+                        capture = None
+
+                    if capture is None:
+                        failure_detected = True
+                        continue
+
+                    if failure_detected:
+                        capture.release()
+                        continue
+
+                    opened[index] = capture
+
+            if failure_detected:
+                for capture in opened.values():
+                    capture.release()
+                return False
+
+        except Exception:
+            sequential_result = open_sequential()
+            if sequential_result is None:
+                return False
+            self._captures = sequential_result
+            return True
 
         self._captures = opened
         return True

--- a/gui.py
+++ b/gui.py
@@ -10,6 +10,7 @@ import cv2
 import numpy as np
 import tkinter as tk
 from tkinter import ttk
+import threading
 
 from camera_capture import MultiCameraCapture
 from filters import invert
@@ -30,6 +31,7 @@ class DualInvertApp:
         self._capture = MultiCameraCapture(self._camera_indices)
         self._photo_images: Dict[Tuple[int, str], tk.PhotoImage] = {}
         self._last_frames: Dict[int, Dict[str, np.ndarray]] = {}
+        self._start_in_progress = False
 
         self.status_var = tk.StringVar(value="Inaktiv. Bitte 'Start' drücken.")
 
@@ -107,15 +109,28 @@ class DualInvertApp:
         return image_label
 
     def start_cameras(self) -> None:
-        if self._capture.is_running():
+        if self._capture.is_running() or self._start_in_progress:
             return
 
-        if not self._capture.start():
-            self.status_var.set("Fehler beim Öffnen der Kameras.")
-            self._capture.stop()
-            return
+        self._start_in_progress = True
+        self.status_var.set("Initialisiere Kameras…")
 
-        self.status_var.set("Live-Ansicht aktiv.")
+        def finalize_start(success: bool) -> None:
+            if success:
+                self.status_var.set("Live-Ansicht aktiv.")
+            else:
+                self.status_var.set("Fehler beim Öffnen der Kameras.")
+                self._capture.stop()
+            self._start_in_progress = False
+
+        def open_cameras() -> None:
+            try:
+                success = self._capture.start()
+            except Exception:
+                success = False
+            self.root.after(0, lambda: finalize_start(success))
+
+        threading.Thread(target=open_cameras, daemon=True).start()
 
     def stop_cameras(self) -> None:
         self._capture.stop()


### PR DESCRIPTION
## Summary
- open individual captures via a helper that sets FPS and reuse it in the sequential fallback
- start multiple cameras concurrently via ThreadPoolExecutor with cleanup on failures
- update the GUI to show initialization status while starting cameras in the background

## Testing
- python -m py_compile camera_capture.py gui.py

------
https://chatgpt.com/codex/tasks/task_e_68dbe085cbe88326ab2c8cf0777ff2f7