### PR TITLE
Add standalone calibration JSON generator script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+captures/
+calibration_captures/
+stereo_calibration.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Camera Capture
+
+Dieses Projekt stellt eine kleine Tk-Anwendung bereit, die zwei Kameras gleichzeitig
+anzeigt, invertierte Graustufen berechnet, Canny-Kanten hervorhebt und – sofern eine
+Stereo-Kalibrierung vorliegt – eine 3D-Tiefenansicht erzeugt.
+
+## Stereo-Kalibrierung durchführen
+
+1. **Schachbrett aufnehmen**  
+   Nimm pro Kamera mehrere synchronisierte Bilder des 6×6-Kalibrierfeldes auf.
+   Die Bilder beider Kameras müssen jeweils dieselbe Auflösung besitzen.
+
+2. **Kalibrierung berechnen**  
+   Verwende das Modul `stereo_reconstruction.py`, um aus den Bildpaaren die
+   Intrinsik und Extrinsik der Kameras zu bestimmen:
+
+   ```python
+   from pathlib import Path
+
+   import cv2
+   import stereo_reconstruction as sr
+
+   # Beispiel: Bilder aus einem Ordner laden
+   pairs = []
+   for i in range(1, 21):
+       left = cv2.imread(f"calib/left_{i:02d}.png")
+       right = cv2.imread(f"calib/right_{i:02d}.png")
+       if left is None or right is None:
+           continue
+       pairs.append((left, right))
+
+   calibration = sr.compute_stereo_calibration(pairs, pattern_size=(6, 6), square_size=1.0)
+   sr.save_calibration(Path("stereo_calibration.json"), calibration)
+   ```
+
+   Das Script erkennt automatisch gültige Schachbrettpaare, optimiert die Ecke
+   subpixelgenau und speichert alle Parameter samt Reprojektionsfehler.
+
+3. **Datei ablegen**  
+   Lege die erzeugte `stereo_calibration.json` im Projektstammverzeichnis ab.
+   Die GUI lädt die Datei beim Start und zeigt in der ersten Kamerazeile ein
+   zusätzliches Panel **„3D Ansicht“** an. Fehlt die Kalibrierung, bleibt das
+   Panel mit einem Hinweis deaktiviert.
+
+## Live-Bedienung
+
+* **Start / Stop** – Öffnet bzw. schließt die konfigurierten Kameras.
+* **Speichern** – Schreibt alle zuletzt angezeigten Ansichten in den Ordner
+  `captures/`.
+* **Refresh Auto Fokus** – Versucht, den Autofokus der Kameras neu zu triggern.
+* **Beenden** – Schließt die Anwendung.
+
+Das Originalbild wird mit ca. 30 FPS aktualisiert. Die Canny-Kanten sowie die
+Stereo-Rekonstruktion laufen aus Performance-Gründen auf ~6–7 FPS.

--- a/README.md
+++ b/README.md
@@ -6,41 +6,50 @@ Stereo-Kalibrierung vorliegt – eine 3D-Tiefenansicht erzeugt.
 
 ## Stereo-Kalibrierung durchführen
 
-1. **Schachbrett aufnehmen**  
-   Nimm pro Kamera mehrere synchronisierte Bilder des 6×6-Kalibrierfeldes auf.
-   Die Bilder beider Kameras müssen jeweils dieselbe Auflösung besitzen.
+1. **Kalibrierung starten**
+   Öffne die Anwendung (`python -m dual_invert_app`) und stelle sicher, dass beide
+   Kameras sichtbar sind. Drücke anschließend im linken Bedienfeld auf
+   **„Stereo Kalibrierung“**. Die Anwendung startet die Kameras automatisch,
+   falls sie zuvor gestoppt waren.
 
-2. **Kalibrierung berechnen**  
-   Verwende das Modul `stereo_reconstruction.py`, um aus den Bildpaaren die
-   Intrinsik und Extrinsik der Kameras zu bestimmen:
+2. **Schachbrett bewegen**
+   Halte das 6×6-Schachbrett nacheinander in verschiedene Positionen und
+   Blickrichtungen. Sobald beide Kameras ein gültiges Muster erkennen, zeichnet
+   die Anwendung ein Bildpaar auf und zeigt den Fortschritt im Statusfeld an.
+   Ziel sind 18 gültige Paare (mindestens 12 sind erforderlich).
 
-   ```python
-   from pathlib import Path
+3. **Automatisches Speichern**
+   Nach erfolgreicher Auswertung speichert die Anwendung
+   `stereo_calibration.json` im Projektstammverzeichnis und legt sämtliche
+   verwendeten Bilder im Ordner `calibration_captures/<timestamp>/` ab.
+   Anschließend steht die Stereo-Ansicht sofort zur Verfügung.
 
-   import cv2
-   import stereo_reconstruction as sr
+### Alternative: Kalibrierung per Skript
 
-   # Beispiel: Bilder aus einem Ordner laden
-   pairs = []
-   for i in range(1, 21):
-       left = cv2.imread(f"calib/left_{i:02d}.png")
-       right = cv2.imread(f"calib/right_{i:02d}.png")
-       if left is None or right is None:
-           continue
-       pairs.append((left, right))
+Falls du lieber offline mit bereits vorhandenen Bildern arbeiten möchtest,
+kannst du weiterhin `stereo_reconstruction.py` direkt verwenden. Sammle deine
+Bildpaare in einem Ordner und führe beispielsweise folgendes Snippet aus:
 
-   calibration = sr.compute_stereo_calibration(pairs, pattern_size=(6, 6), square_size=1.0)
-   sr.save_calibration(Path("stereo_calibration.json"), calibration)
-   ```
+```python
+from pathlib import Path
 
-   Das Script erkennt automatisch gültige Schachbrettpaare, optimiert die Ecke
-   subpixelgenau und speichert alle Parameter samt Reprojektionsfehler.
+import cv2
+import stereo_reconstruction as sr
 
-3. **Datei ablegen**  
-   Lege die erzeugte `stereo_calibration.json` im Projektstammverzeichnis ab.
-   Die GUI lädt die Datei beim Start und zeigt in der ersten Kamerazeile ein
-   zusätzliches Panel **„3D Ansicht“** an. Fehlt die Kalibrierung, bleibt das
-   Panel mit einem Hinweis deaktiviert.
+pairs = []
+for i in range(1, 21):
+    left = cv2.imread(f"calib/left_{i:02d}.png")
+    right = cv2.imread(f"calib/right_{i:02d}.png")
+    if left is None or right is None:
+        continue
+    pairs.append((left, right))
+
+calibration = sr.compute_stereo_calibration(pairs, pattern_size=(6, 6), square_size=1.0)
+sr.save_calibration(Path("stereo_calibration.json"), calibration)
+```
+
+Die erzeugte Datei wird von der Anwendung beim nächsten Start automatisch
+geladen.
 
 ## Live-Bedienung
 

--- a/camera_capture.py
+++ b/camera_capture.py
@@ -45,6 +45,11 @@ class MultiCameraCapture:
                 capture.release()
                 success = False
                 break
+
+            # Drive the live preview at roughly 30 frames per second when
+            # supported by the connected cameras. If the device ignores this
+            # request OpenCV simply retains its default capture rate.
+            capture.set(cv2.CAP_PROP_FPS, 30)
             opened[index] = capture
 
         if not success:

--- a/filters.py
+++ b/filters.py
@@ -1,29 +1,37 @@
-"""Image processing filters for camera frames."""
+"""Grayscale inversion and Canny edge filters for camera frames."""
 from __future__ import annotations
+
+from typing import Tuple
 
 import cv2
 import numpy as np
 
 
-def invert(frame: np.ndarray) -> np.ndarray:
-    """Return a grayscale-inverted frame with red contours highlighting edges.
+def invert_grayscale(frame: np.ndarray) -> np.ndarray:
+    """Convert *frame* to grayscale, invert it, and return a 3-channel image."""
 
-    The input frame is converted to grayscale, inverted, and then converted
-    back to a 3-channel image so it can be rendered alongside color frames in
-    the GUI. Canny edge detection is used to extract the dominant geometry and
-    the detected contours are traced with a red outline for better visibility.
-    """
-    # Convert to grayscale to ensure the inversion only affects luminance.
+    if frame is None or frame.ndim != 3:
+        return frame
+
     gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    inverted = cv2.bitwise_not(gray)
+    return cv2.cvtColor(inverted, cv2.COLOR_GRAY2BGR)
 
-    # Invert the grayscale image and convert it back to BGR for display.
-    inverted_gray = cv2.bitwise_not(gray)
-    inverted_bgr = cv2.cvtColor(inverted_gray, cv2.COLOR_GRAY2BGR)
 
-    # Detect edges and outline their contours in red to highlight geometry.
-    edges = cv2.Canny(gray, 100, 200)
-    contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-    if contours:
-        cv2.drawContours(inverted_bgr, contours, -1, (0, 0, 255), 1)
+def canny_from_inverted(
+    frame: np.ndarray, thresholds: Tuple[int, int] = (60, 180)
+) -> np.ndarray:
+    """Compute a black and white Canny edge map from an inverted image."""
 
-    return inverted_bgr
+    if frame is None:
+        return frame
+
+    if frame.ndim == 3:
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    elif frame.ndim == 2:
+        gray = frame
+    else:
+        return frame
+
+    edges = cv2.Canny(gray, thresholds[0], thresholds[1])
+    return cv2.cvtColor(edges, cv2.COLOR_GRAY2BGR)

--- a/generate_calibration_json.py
+++ b/generate_calibration_json.py
@@ -1,0 +1,118 @@
+"""Command line tool to compute stereo calibration and export JSON."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterator, List, Sequence, Tuple
+
+import cv2
+
+from stereo_reconstruction import compute_stereo_calibration, save_calibration
+
+SUPPORTED_EXTENSIONS: Tuple[str, ...] = (".png", ".jpg", ".jpeg", ".bmp", ".tiff", ".tif")
+
+
+def _iter_image_files(directory: Path) -> Iterator[Path]:
+    """Yield image files from *directory* sorted by name."""
+
+    for path in sorted(directory.iterdir()):
+        if path.suffix.lower() in SUPPORTED_EXTENSIONS and path.is_file():
+            yield path
+
+
+def _load_image_pairs(left_dir: Path, right_dir: Path) -> List[Tuple[cv2.Mat, cv2.Mat]]:
+    """Load image pairs from the provided directories."""
+
+    left_images = list(_iter_image_files(left_dir))
+    right_images = list(_iter_image_files(right_dir))
+
+    if not left_images:
+        raise FileNotFoundError(f"Keine Bilder in {left_dir} gefunden.")
+    if not right_images:
+        raise FileNotFoundError(f"Keine Bilder in {right_dir} gefunden.")
+
+    if len(left_images) != len(right_images):
+        print(
+            "Warnung: Unterschiedliche Anzahl an Dateien – es werden nur die ersten "
+            f"{min(len(left_images), len(right_images))} Paare verwendet."
+        )
+
+    pairs: List[Tuple[cv2.Mat, cv2.Mat]] = []
+    for left_path, right_path in zip(left_images, right_images):
+        left = cv2.imread(str(left_path))
+        right = cv2.imread(str(right_path))
+        if left is None:
+            raise ValueError(f"Konnte Bild nicht lesen: {left_path}")
+        if right is None:
+            raise ValueError(f"Konnte Bild nicht lesen: {right_path}")
+        pairs.append((left, right))
+    return pairs
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Berechnet eine Stereo-Kalibrierung aus linken und rechten Bildern und "
+            "speichert das Ergebnis als JSON."
+        )
+    )
+    parser.add_argument("--left", required=True, help="Ordner mit Bildern der linken Kamera.")
+    parser.add_argument("--right", required=True, help="Ordner mit Bildern der rechten Kamera.")
+    parser.add_argument(
+        "--square-size",
+        type=float,
+        default=1.0,
+        help="Kantenlänge eines Schachbrett-Quadrats in gewünschten Einheiten (Standard: 1.0).",
+    )
+    parser.add_argument(
+        "--pattern-cols",
+        type=int,
+        default=6,
+        help="Anzahl innerer Ecken pro Zeile des Schachbretts (Standard: 6).",
+    )
+    parser.add_argument(
+        "--pattern-rows",
+        type=int,
+        default=6,
+        help="Anzahl innerer Ecken pro Spalte des Schachbretts (Standard: 6).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("stereo_calibration.json"),
+        help="Dateiname der zu erzeugenden JSON-Datei.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+
+    left_dir = Path(args.left)
+    right_dir = Path(args.right)
+
+    if not left_dir.is_dir():
+        raise NotADirectoryError(f"Ordner nicht gefunden: {left_dir}")
+    if not right_dir.is_dir():
+        raise NotADirectoryError(f"Ordner nicht gefunden: {right_dir}")
+
+    print(f"Lade Bildpaare aus {left_dir} und {right_dir} …")
+    image_pairs = _load_image_pairs(left_dir, right_dir)
+
+    print(
+        f"Starte Kalibrierung mit {len(image_pairs)} Paar(en), "
+        f"Schachbrett {args.pattern_cols}x{args.pattern_rows}, Quadratgröße {args.square_size}."
+    )
+
+    calibration = compute_stereo_calibration(
+        image_pairs,
+        pattern_size=(args.pattern_cols, args.pattern_rows),
+        square_size=args.square_size,
+    )
+
+    save_calibration(args.output, calibration)
+    print(f"Kalibrierung gespeichert in {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gui.py
+++ b/gui.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import threading
 from datetime import datetime
 from pathlib import Path
 import time
@@ -15,9 +16,12 @@ from tkinter import ttk
 from camera_capture import MultiCameraCapture
 from filters import canny_from_inverted, invert_grayscale
 from stereo_reconstruction import (
+    StereoCalibrationData,
     StereoReconstructor,
+    compute_stereo_calibration,
     create_default_matcher,
     load_calibration,
+    save_calibration,
 )
 
 
@@ -39,6 +43,11 @@ class DualInvertApp:
         self._stereo_pair: Optional[Tuple[int, int]] = None
         self._stereo_calibration_size: Optional[Tuple[int, int]] = None
         self._load_stereo_configuration()
+
+        self._calibration_in_progress = False
+        self._calibration_pattern_size: Tuple[int, int] = (6, 6)
+        self._calibration_target_pairs = 18
+        self._calibration_min_pairs = 12
 
         capture_frame_size = self._stereo_calibration_size or (640, 360)
         self._capture = MultiCameraCapture(
@@ -82,6 +91,13 @@ class DualInvertApp:
             command=self.refresh_autofocus,
         )
         autofocus_button.pack(fill=tk.X, pady=(5, 0))
+
+        calibrate_button = ttk.Button(
+            control_frame,
+            text="Stereo Kalibrierung",
+            command=self.start_calibration,
+        )
+        calibrate_button.pack(fill=tk.X, pady=(5, 0))
 
         quit_button = ttk.Button(control_frame, text="Beenden", command=self.on_close)
         quit_button.pack(fill=tk.X, pady=(5, 0))
@@ -189,6 +205,165 @@ class DualInvertApp:
     def stop_cameras(self) -> None:
         self._capture.stop()
         self.status_var.set("Aufnahme gestoppt.")
+        self._last_canny_timestamp = None
+
+    def start_calibration(self) -> None:
+        if len(self._camera_indices) < 2:
+            self.status_var.set("Kalibrierung benötigt zwei Kameras.")
+            return
+
+        if self._calibration_in_progress:
+            self.status_var.set("Kalibrierung läuft bereits.")
+            return
+
+        started_for_calibration = False
+        if not self._capture.is_running():
+            if not self._capture.start():
+                self.status_var.set("Kalibrierung fehlgeschlagen: Kameras nicht verfügbar.")
+                self._capture.stop()
+                return
+            started_for_calibration = True
+
+        self._calibration_in_progress = True
+        self.status_var.set(
+            "Kalibrierung gestartet – Schachbrett in verschiedenen Positionen zeigen."
+        )
+
+        left_index, right_index = self._camera_indices[0], self._camera_indices[1]
+
+        thread = threading.Thread(
+            target=self._run_calibration_capture,
+            args=(left_index, right_index, started_for_calibration),
+            daemon=True,
+        )
+        thread.start()
+
+    def _detect_chessboard(self, image: np.ndarray) -> bool:
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        flags = getattr(cv2, "CALIB_CB_FAST_CHECK", 0)
+        found, _ = cv2.findChessboardCorners(gray, self._calibration_pattern_size, flags)
+        return bool(found)
+
+    def _run_calibration_capture(
+        self, left_index: int, right_index: int, started_for_calibration: bool
+    ) -> None:
+        pairs: List[Tuple[np.ndarray, np.ndarray]] = []
+        capture_dir: Optional[Path] = None
+        start_time = time.perf_counter()
+        timeout_seconds = 60
+
+        try:
+            while len(pairs) < self._calibration_target_pairs:
+                if not self._capture.is_running():
+                    break
+
+                left_frame = self._capture.read(left_index)
+                right_frame = self._capture.read(right_index)
+
+                if left_frame is None or right_frame is None:
+                    time.sleep(0.1)
+                    if time.perf_counter() - start_time > timeout_seconds:
+                        break
+                    continue
+
+                if self._detect_chessboard(left_frame) and self._detect_chessboard(right_frame):
+                    if capture_dir is None:
+                        timestamp = datetime.now().strftime("calib_%Y%m%d_%H%M%S")
+                        capture_dir = Path("calibration_captures") / timestamp
+                        capture_dir.mkdir(parents=True, exist_ok=True)
+
+                    pair_index = len(pairs) + 1
+                    left_copy = left_frame.copy()
+                    right_copy = right_frame.copy()
+                    pairs.append((left_copy, right_copy))
+
+                    cv2.imwrite(str(capture_dir / f"left_{pair_index:02d}.png"), left_copy)
+                    cv2.imwrite(str(capture_dir / f"right_{pair_index:02d}.png"), right_copy)
+
+                    self.root.after(
+                        0,
+                        self.status_var.set,
+                        f"Kalibrierung: {pair_index}/{self._calibration_target_pairs} Paare erfasst.",
+                    )
+
+                    time.sleep(0.3)
+                else:
+                    time.sleep(0.05)
+
+                if time.perf_counter() - start_time > timeout_seconds:
+                    break
+
+            if len(pairs) < self._calibration_min_pairs:
+                message = (
+                    "Kalibrierung fehlgeschlagen: zu wenige gültige Schachbrettpaare gefunden."
+                )
+                self.root.after(0, self._finish_calibration, False, message, None, capture_dir)
+                return
+
+            try:
+                calibration = compute_stereo_calibration(
+                    pairs,
+                    pattern_size=self._calibration_pattern_size,
+                )
+            except Exception as exc:  # pragma: no cover - runtime safeguard
+                message = f"Kalibrierung fehlgeschlagen: {exc}"
+                self.root.after(0, self._finish_calibration, False, message, None, capture_dir)
+                return
+
+            try:
+                save_calibration(Path("stereo_calibration.json"), calibration)
+            except Exception as exc:  # pragma: no cover - runtime safeguard
+                message = f"Kalibrierung konnte nicht gespeichert werden: {exc}"
+                self.root.after(0, self._finish_calibration, False, message, None, capture_dir)
+                return
+
+            message = f"Kalibrierung abgeschlossen ({len(pairs)} Paare)."
+            self.root.after(
+                0,
+                self._finish_calibration,
+                True,
+                message,
+                calibration,
+                capture_dir,
+            )
+        finally:
+            if started_for_calibration:
+                self.root.after(0, self._stop_capture_after_calibration)
+
+    def _finish_calibration(
+        self,
+        success: bool,
+        message: str,
+        calibration: Optional[StereoCalibrationData] = None,
+        capture_dir: Optional[Path] = None,
+    ) -> None:
+        if success and calibration is not None:
+            self._apply_new_calibration(calibration)
+        if success and capture_dir is not None:
+            try:
+                relative_dir = capture_dir.relative_to(Path.cwd())
+            except ValueError:
+                relative_dir = capture_dir
+            message = f"{message} Bilder unter '{relative_dir}' gespeichert."
+        self.status_var.set(message)
+        self._calibration_in_progress = False
+
+    def _apply_new_calibration(self, calibration: StereoCalibrationData) -> None:
+        width, height = calibration.image_size
+        self._stereo_calibration_size = (int(width), int(height))
+        if len(self._camera_indices) >= 2:
+            self._stereo_pair = (self._camera_indices[0], self._camera_indices[1])
+        self._stereo_renderer = StereoReconstructor(
+            calibration, matcher=create_default_matcher()
+        )
+        self._stereo_status = None
+        if self._stereo_pair is not None:
+            label = self._labels.get(self._stereo_pair[0], {}).get("3d")
+            if label is not None:
+                label.configure(text="Warte auf Stereo-Daten")
+
+    def _stop_capture_after_calibration(self) -> None:
+        self._capture.stop()
         self._last_canny_timestamp = None
 
     def on_close(self) -> None:

--- a/gui.py
+++ b/gui.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import base64
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
+import time
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -12,11 +13,16 @@ import tkinter as tk
 from tkinter import ttk
 
 from camera_capture import MultiCameraCapture
-from filters import invert
+from filters import canny_from_inverted, invert_grayscale
+from stereo_reconstruction import (
+    StereoReconstructor,
+    create_default_matcher,
+    load_calibration,
+)
 
 
 class DualInvertApp:
-    """GUI application showing original and inverted views for cameras."""
+    """GUI application showing original and processed views for cameras."""
 
     def __init__(
         self,
@@ -27,11 +33,26 @@ class DualInvertApp:
         self.root.title("Dual Kamera Ansicht mit Invertierung")
 
         self._camera_indices: List[int] = list(camera_indices)
-        self._capture = MultiCameraCapture(self._camera_indices)
+
+        self._stereo_renderer: Optional[StereoReconstructor] = None
+        self._stereo_status: Optional[str] = None
+        self._stereo_pair: Optional[Tuple[int, int]] = None
+        self._stereo_calibration_size: Optional[Tuple[int, int]] = None
+        self._load_stereo_configuration()
+
+        capture_frame_size = self._stereo_calibration_size or (640, 360)
+        self._capture = MultiCameraCapture(
+            self._camera_indices,
+            frame_size=capture_frame_size,
+        )
         self._photo_images: Dict[Tuple[int, str], tk.PhotoImage] = {}
         self._last_frames: Dict[int, Dict[str, np.ndarray]] = {}
+        self._live_interval_ms = 33  # ~30 FPS for the live preview
+        self._canny_interval_ms = 150  # ~6-7 FPS for the Canny view
+        self._last_canny_timestamp: Optional[float] = None
 
-        self.status_var = tk.StringVar(value="Inaktiv. Bitte 'Start' drücken.")
+        initial_status = self._stereo_status or "Inaktiv. Bitte 'Start' drücken."
+        self.status_var = tk.StringVar(value=initial_status)
 
         self._build_layout()
         self.root.protocol("WM_DELETE_WINDOW", self.on_close)
@@ -73,20 +94,66 @@ class DualInvertApp:
 
         self._labels: Dict[int, Dict[str, ttk.Label]] = {}
 
+        max_column_index = 0
+
         for row, index in enumerate(self._camera_indices):
-            self._labels[index] = {
-                "original": self._create_image_panel(
-                    video_frame, f"Kamera {row + 1} - Original", row, 0
-                ),
-                "inverted": self._create_image_panel(
-                    video_frame, f"Kamera {row + 1} - Invertiert", row, 1
-                ),
-            }
+            panel_config = [
+                ("original", "Original", "Kein Signal"),
+                ("canny", "Canny (Invertiert)", "Kein Signal"),
+            ]
+            if row == 0 and len(self._camera_indices) >= 2:
+                default_text = (
+                    "Warte auf Stereo-Daten"
+                    if self._stereo_renderer is not None
+                    else (self._stereo_status or "Stereo deaktiviert")
+                )
+                panel_config.append(("3d", "3D Ansicht", default_text))
+            max_column_index = max(max_column_index, len(panel_config) - 1)
+
+            row_labels: Dict[str, ttk.Label] = {}
+            for column, (key, title_suffix, default_text) in enumerate(panel_config):
+                row_labels[key] = self._create_image_panel(
+                    video_frame,
+                    f"Kamera {row + 1} - {title_suffix}",
+                    row,
+                    column,
+                    default_text=default_text,
+                )
+            self._labels[index] = row_labels
 
         for row in range(len(self._camera_indices)):
             video_frame.grid_rowconfigure(row, weight=1)
-        for column in range(2):
+        for column in range(max_column_index + 1):
             video_frame.grid_columnconfigure(column, weight=1)
+
+    def _load_stereo_configuration(self) -> None:
+        self._stereo_renderer = None
+        self._stereo_calibration_size = None
+        self._stereo_pair = None
+        self._stereo_status = None
+
+        if len(self._camera_indices) < 2:
+            self._stereo_status = "Stereo-Ansicht benötigt zwei Kameras."
+            return
+
+        self._stereo_pair = (self._camera_indices[0], self._camera_indices[1])
+        calibration_path = Path("stereo_calibration.json")
+        if not calibration_path.exists():
+            self._stereo_status = (
+                f"Stereo-Ansicht deaktiviert: '{calibration_path.name}' fehlt."
+            )
+            return
+
+        try:
+            calibration = load_calibration(calibration_path)
+        except Exception as exc:  # pragma: no cover - defensive for GUI usage
+            self._stereo_status = f"Stereo-Ansicht deaktiviert: {exc}"
+            return
+
+        width, height = calibration.image_size
+        self._stereo_calibration_size = (int(width), int(height))
+        matcher = create_default_matcher()
+        self._stereo_renderer = StereoReconstructor(calibration, matcher=matcher)
 
     def _create_image_panel(
         self,
@@ -94,6 +161,7 @@ class DualInvertApp:
         title: str,
         row: int,
         column: int,
+        default_text: str = "Kein Signal",
     ) -> ttk.Label:
         panel = ttk.Frame(parent)
         panel.grid(row=row, column=column, padx=5, pady=5, sticky="nsew")
@@ -101,7 +169,7 @@ class DualInvertApp:
         label_title = ttk.Label(panel, text=title, anchor="center")
         label_title.pack(fill=tk.X)
 
-        image_label = ttk.Label(panel, text="Kein Signal", anchor="center")
+        image_label = ttk.Label(panel, text=default_text, anchor="center")
         image_label.pack(fill=tk.BOTH, expand=True)
 
         return image_label
@@ -116,10 +184,12 @@ class DualInvertApp:
             return
 
         self.status_var.set("Live-Ansicht aktiv.")
+        self._last_canny_timestamp = None
 
     def stop_cameras(self) -> None:
         self._capture.stop()
         self.status_var.set("Aufnahme gestoppt.")
+        self._last_canny_timestamp = None
 
     def on_close(self) -> None:
         self.stop_cameras()
@@ -162,32 +232,111 @@ class DualInvertApp:
 
     def _update_loop(self) -> None:
         if self._capture.is_running():
+            frames: Dict[int, np.ndarray] = {}
+            canny_views: Dict[int, np.ndarray] = {}
+            canny_refresh: List[int] = []
+            missing_indices: List[int] = []
+
+            now = time.perf_counter()
+            update_canny = (
+                self._last_canny_timestamp is None
+                or (now - self._last_canny_timestamp) * 1000 >= self._canny_interval_ms
+            )
+            if update_canny:
+                self._last_canny_timestamp = now
+
             for index in self._camera_indices:
                 frame = self._capture.read(index)
-                if frame is not None:
-                    original_frame = frame.copy()
-                    inverted = invert(frame)
+                if frame is None:
+                    missing_indices.append(index)
+                    continue
 
-                    self._last_frames.setdefault(index, {})
-                    self._last_frames[index]["original"] = original_frame
-                    self._last_frames[index]["inverted"] = inverted.copy()
+                original_frame = frame.copy()
+                frames[index] = original_frame
 
-                    self._update_image(
-                        self._labels[index]["original"],
-                        original_frame,
-                        (index, "original"),
-                    )
-                    self._update_image(
-                        self._labels[index]["inverted"],
-                        inverted,
-                        (index, "inverted"),
-                    )
-                else:
-                    self._clear_image(self._labels[index]["original"], (index, "original"))
-                    self._clear_image(self._labels[index]["inverted"], (index, "inverted"))
-                    self._last_frames.pop(index, None)
+                self._last_frames.setdefault(index, {})
+                self._last_frames[index]["original"] = original_frame.copy()
 
-        self.root.after(33, self._update_loop)
+                stored_canny = self._last_frames[index].get("canny")
+                refresh_canny = update_canny or stored_canny is None
+                if refresh_canny:
+                    inverted = invert_grayscale(original_frame)
+                    stored_canny = canny_from_inverted(inverted)
+                    self._last_frames[index]["canny"] = stored_canny.copy()
+                if stored_canny is not None:
+                    canny_views[index] = stored_canny
+                    if refresh_canny:
+                        canny_refresh.append(index)
+
+            for index, original_frame in frames.items():
+                self._update_image(
+                    self._labels[index]["original"],
+                    original_frame,
+                    (index, "original"),
+                )
+            for index in canny_refresh:
+                self._update_image(
+                    self._labels[index]["canny"],
+                    canny_views[index],
+                    (index, "canny"),
+                )
+
+            if (
+                self._stereo_renderer is not None
+                and self._stereo_pair is not None
+                and update_canny
+            ):
+                left_index, right_index = self._stereo_pair
+                left_frame = frames.get(left_index)
+                right_frame = frames.get(right_index)
+                left_canny = canny_views.get(left_index)
+                right_canny = canny_views.get(right_index)
+
+                if (
+                    left_frame is not None
+                    and right_frame is not None
+                    and left_canny is not None
+                    and right_canny is not None
+                    and "3d" in self._labels.get(left_index, {})
+                ):
+                    try:
+                        result = self._stereo_renderer.compute(
+                            left_frame,
+                            right_frame,
+                            masks=(left_canny, right_canny),
+                        )
+                    except Exception as exc:  # pragma: no cover - runtime safety
+                        self.status_var.set(f"Stereo-Fehler: {exc}")
+                        self._clear_stereo_view(left_index)
+                    else:
+                        depth_view = result.depth_colormap
+                        self._last_frames[left_index]["3d"] = depth_view.copy()
+                        self._update_image(
+                            self._labels[left_index]["3d"],
+                            depth_view,
+                            (left_index, "3d"),
+                        )
+                elif self._stereo_pair[0] in self._labels:
+                    self._clear_stereo_view(self._stereo_pair[0])
+
+            for index in missing_indices:
+                if index in self._labels:
+                    for key in ("original", "canny"):
+                        if key in self._labels[index]:
+                            self._clear_image(self._labels[index][key], (index, key))
+                self._last_frames.pop(index, None)
+
+            if self._stereo_pair is not None:
+                left_index, right_index = self._stereo_pair
+                if (
+                    left_index in missing_indices
+                    or right_index in missing_indices
+                    or left_index not in frames
+                    or right_index not in frames
+                ):
+                    self._clear_stereo_view(left_index)
+
+        self.root.after(self._live_interval_ms, self._update_loop)
 
     def _update_image(self, label: ttk.Label, frame, key: Tuple[int, str]) -> None:
         rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
@@ -209,3 +358,17 @@ class DualInvertApp:
             self._last_frames[index].pop(view_name, None)
             if not self._last_frames[index]:
                 self._last_frames.pop(index)
+
+    def _clear_stereo_view(self, left_index: int) -> None:
+        if left_index not in self._labels:
+            return
+        label = self._labels[left_index].get("3d")
+        if label is None:
+            return
+        self._clear_image(label, (left_index, "3d"))
+        message = (
+            "Warte auf Stereo-Daten"
+            if self._stereo_renderer is not None
+            else (self._stereo_status or "Stereo deaktiviert")
+        )
+        label.configure(text=message)

--- a/stereo_reconstruction.py
+++ b/stereo_reconstruction.py
@@ -1,0 +1,401 @@
+"""Utilities for calibrating stereo camera rigs and reconstructing 3D views."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+
+@dataclass
+class StereoCalibrationData:
+    """Container with the intrinsic and extrinsic stereo parameters."""
+
+    image_size: Tuple[int, int]
+    camera_matrix_left: np.ndarray
+    dist_coeffs_left: np.ndarray
+    camera_matrix_right: np.ndarray
+    dist_coeffs_right: np.ndarray
+    rotation_matrix: np.ndarray
+    translation_vector: np.ndarray
+    rectification_matrix_left: np.ndarray
+    rectification_matrix_right: np.ndarray
+    projection_matrix_left: np.ndarray
+    projection_matrix_right: np.ndarray
+    disparity_to_depth_map: np.ndarray
+    reprojection_error: float
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the calibration to a plain dictionary."""
+
+        return {
+            "image_size": list(self.image_size),
+            "camera_matrix_left": self.camera_matrix_left.tolist(),
+            "dist_coeffs_left": self.dist_coeffs_left.tolist(),
+            "camera_matrix_right": self.camera_matrix_right.tolist(),
+            "dist_coeffs_right": self.dist_coeffs_right.tolist(),
+            "rotation_matrix": self.rotation_matrix.tolist(),
+            "translation_vector": self.translation_vector.tolist(),
+            "rectification_matrix_left": self.rectification_matrix_left.tolist(),
+            "rectification_matrix_right": self.rectification_matrix_right.tolist(),
+            "projection_matrix_left": self.projection_matrix_left.tolist(),
+            "projection_matrix_right": self.projection_matrix_right.tolist(),
+            "disparity_to_depth_map": self.disparity_to_depth_map.tolist(),
+            "reprojection_error": float(self.reprojection_error),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "StereoCalibrationData":
+        """Re-create a :class:`StereoCalibrationData` from a JSON dictionary."""
+
+        def _array(key: str) -> np.ndarray:
+            value = data.get(key)
+            if value is None:
+                raise KeyError(f"Missing calibration field '{key}'.")
+            return np.array(value, dtype=np.float64)
+
+        image_size = data.get("image_size")
+        if image_size is None:
+            raise KeyError("Missing calibration field 'image_size'.")
+        width, height = (int(image_size[0]), int(image_size[1]))
+
+        return cls(
+            image_size=(width, height),
+            camera_matrix_left=_array("camera_matrix_left"),
+            dist_coeffs_left=_array("dist_coeffs_left"),
+            camera_matrix_right=_array("camera_matrix_right"),
+            dist_coeffs_right=_array("dist_coeffs_right"),
+            rotation_matrix=_array("rotation_matrix"),
+            translation_vector=_array("translation_vector"),
+            rectification_matrix_left=_array("rectification_matrix_left"),
+            rectification_matrix_right=_array("rectification_matrix_right"),
+            projection_matrix_left=_array("projection_matrix_left"),
+            projection_matrix_right=_array("projection_matrix_right"),
+            disparity_to_depth_map=_array("disparity_to_depth_map"),
+            reprojection_error=float(data.get("reprojection_error", 0.0)),
+        )
+
+
+def _prepare_object_points(
+    pattern_size: Tuple[int, int],
+    square_size: float,
+) -> np.ndarray:
+    cols, rows = pattern_size
+    grid = np.mgrid[0:cols, 0:rows].T.reshape(-1, 2)
+    object_points = np.zeros((rows * cols, 3), np.float32)
+    object_points[:, :2] = grid * square_size
+    return object_points
+
+
+def _find_corners(
+    image: np.ndarray,
+    pattern_size: Tuple[int, int],
+    criteria: Tuple[int, int, float],
+) -> Optional[np.ndarray]:
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    found, corners = cv2.findChessboardCorners(gray, pattern_size)
+    if not found:
+        return None
+    refined = cv2.cornerSubPix(
+        gray,
+        corners,
+        winSize=(11, 11),
+        zeroZone=(-1, -1),
+        criteria=criteria,
+    )
+    return refined
+
+
+def compute_stereo_calibration(
+    image_pairs: Iterable[Tuple[np.ndarray, np.ndarray]],
+    pattern_size: Tuple[int, int] = (6, 6),
+    square_size: float = 1.0,
+) -> StereoCalibrationData:
+    """Compute stereo calibration parameters from chessboard image pairs."""
+
+    criteria = (
+        cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER,
+        100,
+        1e-5,
+    )
+
+    object_points: List[np.ndarray] = []
+    image_points_left: List[np.ndarray] = []
+    image_points_right: List[np.ndarray] = []
+
+    image_size: Optional[Tuple[int, int]] = None
+
+    base_object_points = _prepare_object_points(pattern_size, square_size)
+
+    for left, right in image_pairs:
+        if left is None or right is None:
+            continue
+        if left.shape[:2] != right.shape[:2]:
+            raise ValueError("Stereo pair images must share the same resolution.")
+
+        if image_size is None:
+            image_size = (left.shape[1], left.shape[0])
+
+        corners_left = _find_corners(left, pattern_size, criteria)
+        corners_right = _find_corners(right, pattern_size, criteria)
+
+        if corners_left is None or corners_right is None:
+            continue
+
+        object_points.append(base_object_points.copy())
+        image_points_left.append(corners_left)
+        image_points_right.append(corners_right)
+
+    if not object_points:
+        raise ValueError("Keine gültigen Schachbrettpaare für die Kalibrierung gefunden.")
+
+    if image_size is None:
+        raise ValueError("Die Bildgröße der Kalibrierung konnte nicht bestimmt werden.")
+
+    rms, camera_matrix_left, dist_coeffs_left, camera_matrix_right, dist_coeffs_right, rotation_matrix, translation_vector, _, _ = (
+        cv2.stereoCalibrate(
+            object_points,
+            image_points_left,
+            image_points_right,
+            None,
+            None,
+            None,
+            None,
+            image_size,
+            criteria=criteria,
+            flags=0,
+        )
+    )
+
+    (
+        rectification_matrix_left,
+        rectification_matrix_right,
+        projection_matrix_left,
+        projection_matrix_right,
+        disparity_to_depth_map,
+        _,
+        _,
+    ) = cv2.stereoRectify(
+        camera_matrix_left,
+        dist_coeffs_left,
+        camera_matrix_right,
+        dist_coeffs_right,
+        image_size,
+        rotation_matrix,
+        translation_vector,
+        flags=cv2.CALIB_ZERO_DISPARITY,
+        alpha=0,
+    )
+
+    return StereoCalibrationData(
+        image_size=image_size,
+        camera_matrix_left=camera_matrix_left,
+        dist_coeffs_left=dist_coeffs_left,
+        camera_matrix_right=camera_matrix_right,
+        dist_coeffs_right=dist_coeffs_right,
+        rotation_matrix=rotation_matrix,
+        translation_vector=translation_vector,
+        rectification_matrix_left=rectification_matrix_left,
+        rectification_matrix_right=rectification_matrix_right,
+        projection_matrix_left=projection_matrix_left,
+        projection_matrix_right=projection_matrix_right,
+        disparity_to_depth_map=disparity_to_depth_map,
+        reprojection_error=rms,
+    )
+
+
+def save_calibration(path: Path, calibration: StereoCalibrationData) -> None:
+    """Persist calibration data as JSON."""
+
+    path = Path(path)
+    path.write_text(json.dumps(calibration.to_dict(), indent=2), encoding="utf-8")
+
+
+def load_calibration(path: Path) -> StereoCalibrationData:
+    """Load calibration parameters from *path*."""
+
+    path = Path(path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return StereoCalibrationData.from_dict(data)
+
+
+def create_default_matcher(
+    min_disparity: int = 0,
+    num_disparities: int = 128,
+    block_size: int = 5,
+) -> cv2.StereoMatcher:
+    """Create a default StereoSGBM matcher suitable for medium resolutions."""
+
+    num_disparities = max(16, int(np.ceil(num_disparities / 16)) * 16)
+    matcher = cv2.StereoSGBM_create(
+        minDisparity=min_disparity,
+        numDisparities=num_disparities,
+        blockSize=block_size,
+        P1=8 * 3 * block_size ** 2,
+        P2=32 * 3 * block_size ** 2,
+        mode=cv2.STEREO_SGBM_MODE_SGBM_3WAY,
+    )
+    matcher.setUniquenessRatio(10)
+    matcher.setSpeckleWindowSize(100)
+    matcher.setSpeckleRange(32)
+    matcher.setDisp12MaxDiff(1)
+    matcher.setPreFilterCap(63)
+    matcher.setP1(8 * 3 * block_size ** 2)
+    matcher.setP2(32 * 3 * block_size ** 2)
+    return matcher
+
+
+@dataclass
+class StereoReconstructionResult:
+    """Result of a single stereo reconstruction step."""
+
+    rectified_left: np.ndarray
+    rectified_right: np.ndarray
+    disparity: np.ndarray
+    depth_colormap: np.ndarray
+    point_cloud: np.ndarray
+    mask: np.ndarray
+
+    def filtered_points(self) -> np.ndarray:
+        """Return only valid 3D points."""
+
+        valid = self.mask.reshape(-1)
+        points = self.point_cloud.reshape(-1, 3)
+        return points[valid]
+
+
+class StereoReconstructor:
+    """Convenience wrapper that caches rectification maps and computes depth."""
+
+    def __init__(
+        self,
+        calibration: StereoCalibrationData,
+        matcher: Optional[cv2.StereoMatcher] = None,
+    ) -> None:
+        self.calibration = calibration
+        self.matcher = matcher or create_default_matcher()
+        self._map_cache: Dict[Tuple[int, int], Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
+
+    def _get_maps(
+        self, image_size: Tuple[int, int]
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        if image_size not in self._map_cache:
+            map_left = cv2.initUndistortRectifyMap(
+                self.calibration.camera_matrix_left,
+                self.calibration.dist_coeffs_left,
+                self.calibration.rectification_matrix_left,
+                self.calibration.projection_matrix_left,
+                image_size,
+                cv2.CV_32FC1,
+            )
+            map_right = cv2.initUndistortRectifyMap(
+                self.calibration.camera_matrix_right,
+                self.calibration.dist_coeffs_right,
+                self.calibration.rectification_matrix_right,
+                self.calibration.projection_matrix_right,
+                image_size,
+                cv2.CV_32FC1,
+            )
+            self._map_cache[image_size] = (*map_left, *map_right)
+        return self._map_cache[image_size]
+
+    def _rectify_pair(
+        self,
+        left: np.ndarray,
+        right: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray, Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
+        if left.shape[:2] != right.shape[:2]:
+            raise ValueError("Linkes und rechtes Bild müssen gleich groß sein.")
+
+        height, width = left.shape[:2]
+        if (width, height) != self.calibration.image_size:
+            raise ValueError(
+                "Die Auflösung der Live-Bilder entspricht nicht der Kalibrierung."
+            )
+
+        map1_left, map2_left, map1_right, map2_right = self._get_maps((width, height))
+        rect_left = cv2.remap(left, map1_left, map2_left, cv2.INTER_LINEAR)
+        rect_right = cv2.remap(right, map1_right, map2_right, cv2.INTER_LINEAR)
+        return rect_left, rect_right, (map1_left, map2_left, map1_right, map2_right)
+
+    @staticmethod
+    def _remap_mask(mask: np.ndarray, map1: np.ndarray, map2: np.ndarray) -> np.ndarray:
+        if mask.ndim == 3:
+            mask = cv2.cvtColor(mask, cv2.COLOR_BGR2GRAY)
+        rect_mask = cv2.remap(mask, map1, map2, cv2.INTER_NEAREST)
+        return rect_mask
+
+    def compute(
+        self,
+        left: np.ndarray,
+        right: np.ndarray,
+        masks: Optional[Tuple[np.ndarray, np.ndarray]] = None,
+    ) -> StereoReconstructionResult:
+        """Compute a depth map and point cloud from *left* and *right* frames."""
+
+        rect_left, rect_right, maps = self._rectify_pair(left, right)
+        map1_left, map2_left, map1_right, map2_right = maps
+
+        gray_left = cv2.cvtColor(rect_left, cv2.COLOR_BGR2GRAY)
+        gray_right = cv2.cvtColor(rect_right, cv2.COLOR_BGR2GRAY)
+
+        disparity_raw = self.matcher.compute(gray_left, gray_right).astype(np.float32)
+        disparity = disparity_raw / 16.0
+
+        mask = np.isfinite(disparity)
+        mask &= disparity > 0
+
+        if masks is not None:
+            left_mask, right_mask = masks
+            left_mask_rect = self._remap_mask(left_mask, map1_left, map2_left)
+            right_mask_rect = self._remap_mask(right_mask, map1_right, map2_right)
+            combined_mask = cv2.bitwise_or(left_mask_rect, right_mask_rect)
+            mask &= combined_mask > 0
+
+        point_cloud = cv2.reprojectImageTo3D(disparity, self.calibration.disparity_to_depth_map)
+        point_cloud = np.where(mask[..., None], point_cloud, np.nan)
+
+        depth_colormap = _colorize_disparity(disparity, mask)
+
+        return StereoReconstructionResult(
+            rectified_left=rect_left,
+            rectified_right=rect_right,
+            disparity=disparity,
+            depth_colormap=depth_colormap,
+            point_cloud=point_cloud,
+            mask=mask,
+        )
+
+
+def _colorize_disparity(disparity: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    if disparity.size == 0:
+        return np.zeros((*disparity.shape, 3), dtype=np.uint8)
+
+    valid_values = disparity[mask]
+    if valid_values.size == 0:
+        return np.zeros((*disparity.shape, 3), dtype=np.uint8)
+
+    disp_min = np.nanmin(valid_values)
+    disp_max = np.nanmax(valid_values)
+    if disp_max - disp_min < 1e-3:
+        disp_max = disp_min + 1e-3
+
+    normalized = (disparity - disp_min) / (disp_max - disp_min)
+    normalized = np.clip(normalized, 0, 1)
+    normalized_uint8 = (normalized * 255).astype(np.uint8)
+    colored = cv2.applyColorMap(normalized_uint8, cv2.COLORMAP_TURBO)
+    colored[~mask] = 0
+    return colored
+
+
+def load_reconstructor(
+    path: Path,
+    matcher: Optional[cv2.StereoMatcher] = None,
+) -> StereoReconstructor:
+    """Load calibration data from *path* and build a :class:`StereoReconstructor`."""
+
+    calibration = load_calibration(path)
+    return StereoReconstructor(calibration, matcher=matcher)


### PR DESCRIPTION
## Summary
- add a small CLI script that loads stereo image pairs and computes calibration parameters
- write the resulting parameters to a JSON file using the existing stereo reconstruction utilities

## Testing
- python -m compileall generate_calibration_json.py

------
https://chatgpt.com/codex/tasks/task_e_68cbcdc0eddc83268dfd0d29daff313c